### PR TITLE
damage_multiplier option for powers

### DIFF
--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -110,6 +110,7 @@ struct Power {
 	bool no_attack;
 	int radius;
 	int base_damage; // enum.  damage is powered by melee, ranged, mental weapon
+	int damage_multiplier; // % of base damage done by power (eg. 200 doubles damage and 50 halves it)
 	int starting_pos; // enum. (source, target, or melee)
 	bool multitarget;
 	
@@ -176,6 +177,7 @@ struct Power {
 		radius = 0;
 		starting_pos = STARTING_POS_SOURCE;
 		base_damage = BASE_DAMAGE_NONE;
+		damage_multiplier = 100;
 		multitarget = false;
 
 		trait_elemental = -1;


### PR DESCRIPTION
Added configurable damage_multiplier option to attack powers, heal, and shield. For example, damage_multiplier=100 is default, damage_multiplier=200 will double the effect, damage_multiplier=50 will halve the effect.
