### PR TITLE
Refactored missilex3 into missile

### DIFF
--- a/enemies/sir_evan_maddox.txt
+++ b/enemies/sir_evan_maddox.txt
@@ -19,7 +19,7 @@ chance_pursue=25
 chance_melee_phys=25
 chance_ranged_ment=2
 power_melee_phys=1
-power_ranged_ment=14
+power_ranged_ment=35
 
 accuracy=93
 avoidance=43

--- a/powers/powers.txt
+++ b/powers/powers.txt
@@ -123,8 +123,6 @@ trait_elemental=wind
 trait_crits_impaired=25
 post_power=126
 wall_power=126
-missile_num=15
-missile_angle=24
 
 [power]
 id=7
@@ -458,6 +456,33 @@ frame_size=64,64
 frame_offset=32,64
 wall_power=124
 
+[power]
+id=35
+name=Maddox's Ice Storm [enemy]
+type=missile
+new_state=cast
+face=true
+directional=true
+gfx=icicle.png
+sfx=shock.ogg
+use_hazard=true
+rendered=true
+aim_assist=32
+base_damage=ment
+lifespan=32
+radius=64
+speed=30
+frame_loop=12
+frame_duration=3
+frame_size=64,64
+frame_offset=32,64
+trait_elemental=water
+slow_duration=60
+post_power=126
+wall_power=126
+#missile num needs to be odd, or the player can avoid just by standing there
+missile_num=9
+missile_angle=40
 
 
 [power]
@@ -529,7 +554,7 @@ id=115
 name=Lightning Rod
 type=missile
 icon=101
-description=Channel a bolt of magic through your mental weapon
+description=Create a destructive blast of lightning bolts
 new_state=cast
 face=true
 directional=true
@@ -550,6 +575,9 @@ trait_elemental=wind
 post_power=126
 wall_power=126
 requires_item=1021
+missile_num=5
+angle_variance=15
+speed_variance=7
 
 [power]
 id=118

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -117,6 +117,8 @@ struct Power {
 	//missile traits
 	int missile_num;
 	int missile_angle;
+	int angle_variance;
+	int speed_variance;
 
 	int trait_elemental; // enum. of elements
 	bool trait_armor_penetration;
@@ -186,6 +188,8 @@ struct Power {
 
 		missile_num = 1;
 		missile_angle = 0;
+		angle_variance = 0;
+		speed_variance = 0;
 
 		trait_elemental = -1;
 		trait_armor_penetration = false;


### PR DESCRIPTION
Now missile powers can have the following attributes:
missile_num: the number of missiles it will shoot
missile_angle: the angle between the missiles
angle_variance: (in degrees) the missiles can deviate from the intended angle (randomly)
speed_variance: the missiles' speed can deviate this much from the specified speed (randomly)

Since this opens up many, many different power options, I included an update for Sir Evan Maddox's ranged power (fight him and see... it's a pretty exciting fight), as well as the Lightning Rod's power (which demonstrates use of all 4 attributes).
