### PR TITLE
Bugfix: skeleton animation freezes and causes infinite melee loop

### DIFF
--- a/animations/skeleton.txt
+++ b/animations/skeleton.txt
@@ -14,7 +14,7 @@ type=looped
 position=12
 frames=4
 duration=90
-type=melee
+type=play_once
 
 [ment]
 position=16


### PR DESCRIPTION
The type was accidentally set to 'melee' instead of 'play_once,' causing a freeze in the animation and the area around the skeleton to become an infinite hazard loop deathtrap. Yikes!
