### PR TITLE
Vampiric Effects for HP and MP; Hazards now have pointer to StatBlock of the source.

### DIFF
--- a/powers/powers.txt
+++ b/powers/powers.txt
@@ -29,6 +29,8 @@ lifespan=1
 radius=64
 starting_pos=melee
 allow_power_mod=true
+hp_steal=100
+mp_steal=100
 
 [power]
 id=2
@@ -511,6 +513,23 @@ wall_power=126
 missile_num=9
 missile_angle=40
 
+[power]
+id=36
+name=Vampiric Strike
+type=effect
+icon=1
+description=Turn 50% of damage you deal into HP
+new_state=swing
+face=true
+use_hazard=true
+rendered=false
+aim_assist=32
+base_damage=melee
+lifespan=1
+radius=64
+starting_pos=melee
+allow_power_mod=true
+hp_steal=50
 
 [power]
 id=100

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -556,6 +556,14 @@ bool Avatar::takeHit(Hazard h) {
 			if (h.slow_duration > stats.slow_duration) stats.slow_duration = h.slow_duration;
 			if (h.bleed_duration > stats.bleed_duration) stats.bleed_duration = h.bleed_duration;
 			if (h.immobilize_duration > stats.immobilize_duration) stats.immobilize_duration = h.immobilize_duration;
+			if (h.hp_steal != 0) {
+				h.src_stats->hp += ceil(dmg * (h.hp_steal / 100.0));
+				if (h.src_stats->hp > h.src_stats->maxhp) h.src_stats->hp = h.src_stats->maxhp;
+			}
+			/*if (h.mp_steal != 0) { //enemies don't have MP
+				h.src_stats->mp += ceil(dmg * (h.mp_steal / 100.0));
+				if (h.src_stats->mp > h.src_stats->maxmp) h.src_stats->mp = h.src_stats->maxmp;
+			}*/
 		}
 		
 		// post effect power

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -510,6 +510,14 @@ bool Enemy::takeHit(Hazard h) {
 			if (h.slow_duration > stats.slow_duration) stats.slow_duration = h.slow_duration;
 			if (h.bleed_duration > stats.bleed_duration) stats.bleed_duration = h.bleed_duration;
 			if (h.immobilize_duration > stats.immobilize_duration) stats.immobilize_duration = h.immobilize_duration;
+			if (h.hp_steal != 0) {
+				h.src_stats->hp += ceil(dmg * (h.hp_steal / 100.0));
+				if (h.src_stats->hp > h.src_stats->maxhp) h.src_stats->hp = h.src_stats->maxhp;
+			}
+			if (h.mp_steal != 0) {
+				h.src_stats->mp += ceil(dmg * (h.mp_steal / 100.0));
+				if (h.src_stats->mp > h.src_stats->maxmp) h.src_stats->mp = h.src_stats->maxmp;
+			}
 		}
 		
 		// post effect power

--- a/src/Hazard.cpp
+++ b/src/Hazard.cpp
@@ -11,6 +11,7 @@
 #include "Hazard.h"
 
 Hazard::Hazard() {
+	src_stats = NULL;
 	sprites = NULL;
 	speed.x = 0.0;
 	speed.y = 0.0;
@@ -39,6 +40,8 @@ Hazard::Hazard() {
 	immobilize_duration=0;
 	slow_duration=0;
 	bleed_duration=0;
+	hp_steal=0;
+	mp_steal=0;
 	trait_armor_penetration = false;
 	trait_crits_impaired = 0;
 	trait_elemental = -1;

--- a/src/Hazard.h
+++ b/src/Hazard.h
@@ -16,11 +16,7 @@
 #include "SDL_mixer.h"
 #include "Utils.h"
 #include "MapCollision.h"
-
-// Hazard Sources
-const int SRC_HERO = 0;
-const int SRC_ENEMY = 1;
-const int SRC_NEUTRAL = 2;
+#include "StatBlock.h"
 
 class Hazard {
 private:
@@ -28,12 +24,13 @@ private:
 public:
 	Hazard();
 	
+	StatBlock *src_stats;
+
 	SDL_Surface *sprites;
 	void setCollision(MapCollision *_collider);
 	void logic();
 
-	int source;
-	int enemyIndex;
+	//int enemyIndex; //don't know what this does... doesn't look like it's ever used.
 	
 	int dmg_min;
 	int dmg_max;
@@ -75,6 +72,8 @@ public:
 	int immobilize_duration;
 	int slow_duration;
 	int bleed_duration;
+	int hp_steal;
+	int mp_steal;
 	
 	bool trait_armor_penetration;
 	int trait_crits_impaired;

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -223,6 +223,13 @@ void PowerManager::loadPowers() {
 						else if (val == "shadow") powers[input_id].trait_elemental = ELEMENT_SHADOW;
 						else if (val == "light") powers[input_id].trait_elemental = ELEMENT_LIGHT;
 					}
+					//steal effects
+					else if (key == "hp_steal") {
+						powers[input_id].hp_steal = atoi(val.c_str());
+					}
+					else if (key == "mp_steal") {
+						powers[input_id].mp_steal = atoi(val.c_str());
+					}
 					//missile modifiers
 					else if (key == "missile_num") {
 						powers[input_id].missile_num = atoi(val.c_str());
@@ -441,12 +448,8 @@ int PowerManager::calcDirection(int origin_x, int origin_y, int target_x, int ta
  */
 void PowerManager::initHazard(int power_index, StatBlock *src_stats, Point target, Hazard *haz) {
 
-	// the source (hero/enemy/neutral) determines what is a valid target
-	// i.e. no friendly fire between enemies
-	if (src_stats->hero)
-		haz->source = SRC_HERO;
-	else
-		haz->source = SRC_ENEMY;
+	//the hazard holds the statblock of its source
+	haz->src_stats = src_stats;
 
 	// Hazard attributes based on power source
 	haz->crit_chance = src_stats->crit;
@@ -541,6 +544,9 @@ void PowerManager::initHazard(int power_index, StatBlock *src_stats, Point targe
 	haz->stun_duration += powers[power_index].stun_duration;
 	haz->slow_duration += powers[power_index].slow_duration;
 	haz->immobilize_duration += powers[power_index].immobilize_duration;
+	// steal effects
+	haz->hp_steal += powers[power_index].hp_steal;
+	haz->mp_steal += powers[power_index].mp_steal;
 	
 	// hazard starting position
 	if (powers[power_index].starting_pos == STARTING_POS_SOURCE) {
@@ -847,10 +853,7 @@ bool PowerManager::single(int power_index, StatBlock *src_stats, Point target) {
 	haz->lifespan = 1;
 	haz->crit_chance = src_stats->crit;
 	haz->accuracy = src_stats->accuracy;
-	if (src_stats->hero)
-		haz->source = SRC_HERO;
-	else
-		haz->source = SRC_ENEMY;
+	haz->src_stats = src_stats;
 
 	// specific powers have different stats here
 	if (power_index == POWER_VENGEANCE) {

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -111,6 +111,10 @@ struct Power {
 	int damage_multiplier; // % of base damage done by power (eg. 200 doubles damage and 50 halves it)
 	int starting_pos; // enum. (source, target, or melee)
 	bool multitarget;
+
+	//steal effects (in %, eg. hp_steal=50 turns 50% damage done into HP regain.)
+	int hp_steal;
+	int mp_steal;
 	
 	//missile traits
 	int missile_num;


### PR DESCRIPTION
Added Vampiric effects for HP and MP. You can now add the following to any attack power:

```
hp_steal=50
mp_steal=100
```

To regain 50% of your damage in HP and 100% of your damage in MP. These only function on damage actually done to the target. Also, 100 is really powerful. I could keep up with a pretty big mob with nothing but my fists.

Also changed Hazards to have a pointer to the StatBlock of the source.
