### PR TITLE
On-click events

### DIFF
--- a/maps/goblin_warrens.txt
+++ b/maps/goblin_warrens.txt
@@ -276,6 +276,7 @@ intermap=cave1.txt,3,13
 type=run_once
 location=3,36,1,1
 hotspot=-32,-32,64,64
+tooltip=Ukkonen's chest
 mapmod=object,3,36,160
 soundfx=soundfx/wood_open.ogg
 loot=random,4,36,2
@@ -285,7 +286,7 @@ loot=random,4,36,2
 type=run_once
 location=1,32,1,1
 hotspot=-32,-32,64,64
-tooltip=Barrel of loot
+tooltip=Barrel
 mapmod=object,1,32,162
 soundfx=soundfx/wood_open.ogg
 loot=random,2,32,1
@@ -295,6 +296,7 @@ loot=random,2,32,1
 type=run_once
 location=2,28,1,1
 hotspot=-32,-32,64,64
+tooltip=Averguard Tome
 requires_status=ak_ukkonen_search
 requires_not=ak_tome_found
 mapmod=object,2,28,165
@@ -304,18 +306,18 @@ loot=id,2,29,9000
 
 [event]
 #overlook book 1
-type=run_once
 location=38,51,1,1
 hotspot=-32,-32,64,64
+tooltip=History of the Averguard: Ch. 1
 mapmod=object,38,51,164
 soundfx=soundfx/inventory/inventory_page.ogg
 msg="In the Age of Settlement, the Averguard Knights defended peasants against the chaos of the wilderness."
 
 [event]
 #overlook book 2
-type=run_once
 location=38,46,1,1
 hotspot=-32,-32,64,64
+tooltip=History of the Averguard: Ch. 2
 mapmod=object,38,46,164
 soundfx=soundfx/inventory/inventory_page.ogg
 msg="Sir Evan Maddox led the Averguard when the plague struck.  Powerful clerics from the corners of the world were brought here.  By the time a cure was found it was too late."

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -29,7 +29,7 @@ GameStatePlay::GameStatePlay(SDL_Surface *_screen, InputState *_inp, FontEngine 
 	powers = new PowerManager();
 	font = _font;
 	camp = new CampaignManager();
-	map = new MapIso(_screen, camp, _inp);
+	map = new MapIso(_screen, camp, _inp, font);
 	pc = new Avatar(powers, _inp, map);
 	enemies = new EnemyManager(powers, map);
 	hazards = new HazardManager(powers, pc, enemies);

--- a/src/MapIso.h
+++ b/src/MapIso.h
@@ -23,6 +23,7 @@
 #include "CampaignManager.h"
 #include "EnemyGroupManager.h"
 #include "InputState.h"
+#include "MenuTooltip.h"
 
 using namespace std;
 
@@ -55,13 +56,16 @@ struct Map_Event {
 	string tooltip;
 };
 
-const int CLICK_RANGE = 3 * UNITS_PER_TILE;
+const int CLICK_RANGE = 3 * UNITS_PER_TILE; //for activating events
 
 class MapIso {
 private:
 	SDL_Surface *screen;
 	InputState *inp;
 	Mix_Music *music;
+	FontEngine *font;
+
+	MenuTooltip *tip;
 
 	// map events can play random soundfx
 	Mix_Chunk *sfx;
@@ -77,11 +81,10 @@ private:
 	int event_count;
 	
 public:
-
 	CampaignManager *camp;
 
 	// functions
-	MapIso(SDL_Surface *_screen, CampaignManager *_camp, InputState *_inp);
+	MapIso(SDL_Surface *_screen, CampaignManager *_camp, InputState *_inp, FontEngine *_font);
 	~MapIso();
 	void clearEnemy(Map_Enemy e);
 	void clearNPC(Map_NPC n);
@@ -94,6 +97,7 @@ public:
 	void checkEvents(Point loc);
 	void checkEventClick();
 	void clearEvents();
+	void checkTooltip();
 
 	// vars
 	string title;


### PR DESCRIPTION
Added on-click events and tested on Goblin Warrens.
- Can activate whenever you are within 3 squares (same range as loot)
- Changed all applicable events in Goblin Warrens to use new event styles
- Books in Goblin Warrens can now be read multiple times
- Tooltips appear when mouse hovers over and the event has not yet triggered. Will not appear if requires_not is set. (Test Averguard Tome for an example)

If this is how you want it, I'll go through the rest of the maps and convert them over too. (Perhaps adding enemy groups at the same time?)
