### PR TITLE
Refactored post_power to use hazard source as source

### DIFF
--- a/powers/powers.txt
+++ b/powers/powers.txt
@@ -750,7 +750,7 @@ frame_duration=1
 frame_size=64,64
 frame_offset=32,64
 frame_loop=1
-starting_pos=source
+starting_pos=target
 
 [power]
 id=125
@@ -765,7 +765,7 @@ frame_duration=4
 frame_size=64,64
 frame_offset=32,64
 frame_loop=100
-starting_pos=source
+starting_pos=target
 visual_random=2
 
 [power]
@@ -781,7 +781,7 @@ frame_duration=4
 frame_size=64,64
 frame_offset=32,64
 frame_loop=100
-starting_pos=source
+starting_pos=target
 visual_random=2
 
 [power]
@@ -797,7 +797,7 @@ frame_duration=4
 frame_size=64,64
 frame_offset=32,64
 frame_loop=100
-starting_pos=source
+starting_pos=target
 visual_random=2
 
 [power]

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -533,7 +533,7 @@ bool Enemy::takeHit(Hazard h) {
 		Point pt;
 		pt.x = pt.y = 0;
 		if (h.post_power >= 0 && dmg > 0) {
-			powers->activate(h.post_power, &stats, pt);
+			powers->activate(h.post_power, h.src_stats, stats.pos);
 		}
 		
 		// interrupted to new state

--- a/src/HazardManager.cpp
+++ b/src/HazardManager.cpp
@@ -37,16 +37,13 @@ void HazardManager::logic() {
 		
 		// if a moving hazard hits a wall, check for an after-effect
 		if (h[i]->hit_wall && h[i]->wall_power >= 0) {
-			Point pt;
-			StatBlock sb;
-			sb.pos.x = (int)(h[i]->pos.x);
-			sb.pos.y = (int)(h[i]->pos.y);
+			Point target;
+			target.x = (int)(h[i]->pos.x);
+			target.y = (int)(h[i]->pos.y);
 			
-			if (powers->powers[h[i]->wall_power].directional) {
-				pt = round(calcVector(sb.pos,h[i]->direction,64));
-			}
+			powers->activate(h[i]->wall_power, h[i]->src_stats, target);
+			if (powers->powers[h[i]->wall_power].directional) powers->hazards.back()->direction = h[i]->direction;
 			
-			powers->activate(h[i]->wall_power, &sb, pt);
 		}
 		
 	}


### PR DESCRIPTION
Try adding the following powers to test.

```
[power]
id=132
name=Chain Lightning (Post Effect)
type=missile
missile_num=3
missile_angle=120
angle_variance=60
damage_multiplier=20
starting_pos=target
directional=true
gfx=lightning.png
sfx=shock.ogg
use_hazard=true
rendered=true
aim_assist=32
base_damage=ment
lifespan=32
radius=64
speed=32
frame_loop=4
frame_duration=1
frame_size=64,64
frame_offset=32,64
trait_elemental=wind
post_power=126
wall_power=126

[power]
id=133
name=Fireball (Post Effect)
type=effect
new_state=cast
face=true
gfx=blast.png
sfx=burn.ogg
use_hazard=true
rendered=true
base_damage=ment
lifespan=18
radius=128
frame_duration=2
frame_size=256,128
frame_offset=128,64
frame_loop=0
floor=true
active_frame=4
trait_elemental=fire
starting_pos=target
multitarget=true
post_power=125
```
