### PR TITLE
Bugfix on entity collisions?

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -525,13 +525,6 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 bool Avatar::takeHit(Hazard h) {
 
 	if (stats.cur_state != AVATAR_DEAD) {
-	
-	        bool repeat = h.hasEntity(this);
-	
-		if(!repeat) h.addEntity(this);
-		
-		// Auto-miss if hazard has already hit this entity
-		if(repeat) return false;
 		// check miss
 		int avoidance = stats.avoidance;
 		if (stats.blocking) avoidance *= 2;

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -456,12 +456,6 @@ void Enemy::logic() {
 bool Enemy::takeHit(Hazard h) {
 	if (stats.cur_state != ENEMY_DEAD && stats.cur_state != ENEMY_CRITDEAD) 
 	{
-		/* Make sure hazard hasn't been hit before. This assumes Hazards hit a
-		 relatively small number of Entities, so a linear search isn't too bad.
-		*/
-               
-		bool repeat = h.hasEntity(this);
-		if(!repeat) h.addEntity(this);
 
 		if (!stats.in_combat) {
 			stats.in_combat = true;
@@ -472,9 +466,6 @@ bool Enemy::takeHit(Hazard h) {
 
 		// exit if it was a beacon (to prevent stats.targeted from being set)
 		if (powers->powers[h.power_index].beacon) return false;
-
-		// auto-miss if Hazard has already hit this Entity
-		if (repeat) return false;
 
 		// if it's a miss, do nothing
 		if (rand() % 100 > (h.accuracy - stats.avoidance + 25)) return false; 

--- a/src/HazardManager.cpp
+++ b/src/HazardManager.cpp
@@ -61,11 +61,14 @@ void HazardManager::logic() {
 					// only check living enemies
 					if (enemies->enemies[eindex]->stats.hp > 0 && h[i]->active) {
 						if (isWithin(round(h[i]->pos), h[i]->radius, enemies->enemies[eindex]->stats.pos)) {
-							// hit!
-							hit = enemies->enemies[eindex]->takeHit(*h[i]);
-							if (!h[i]->multitarget && hit) {
-								h[i]->active = false;
-								if (!h[i]->complete_animation) h[i]->lifespan = 0;
+							if (!h[i]->hasEntity(enemies->enemies[eindex])) {
+								h[i]->addEntity(enemies->enemies[eindex]);
+								// hit!
+								hit = enemies->enemies[eindex]->takeHit(*h[i]);
+								if (!h[i]->multitarget && hit) {
+									h[i]->active = false;
+									if (!h[i]->complete_animation) h[i]->lifespan = 0;
+								}
 							}
 						}
 					}
@@ -77,11 +80,14 @@ void HazardManager::logic() {
 			if (h[i]->source_type != SOURCE_TYPE_HERO) { //enemy or neutral sources
 				if (hero->stats.hp > 0 && h[i]->active) {
 					if (isWithin(round(h[i]->pos), h[i]->radius, hero->stats.pos)) {
-						// hit!
-						hit = hero->takeHit(*h[i]);
-						if (!h[i]->multitarget && hit) {
-							h[i]->active = false;
-							if (!h[i]->complete_animation) h[i]->lifespan = 0;
+						if (!h[i]->hasEntity(hero)) {
+							h[i]->addEntity(hero);
+							// hit!
+							hit = hero->takeHit(*h[i]);
+							if (!h[i]->multitarget && hit) {
+								h[i]->active = false;
+								if (!h[i]->complete_animation) h[i]->lifespan = 0;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
I'm not really sure what the problem was, but on my machine the entity collider list didn't ever register the enemy as hit. (Hazard::hasEntity() for some reason never executed). If this isn't a problem for you, then ignore this pull request; I must've done something wrong.

A good way to test and see if the entity collision list works properly is see if your missiles ever miss. If they don't ever miss, it's probably because they get several chances to hit. Another way is to fire a multitarget power, such as Piercing Shot to see if it hits the target multiple times. (I could kill Maddox in one hit with that power).

If you are having this problem too, this patch should fix it. (I just moved the code to a different area. A nice side-effect of this is that it actually shortened the code as well.)
