### PR TITLE
Removed MessageEngine from StatBlock

### DIFF
--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -367,7 +367,6 @@ void GameStateLoad::render() {
 	}
 	
 	Point label;
-	stringstream ss;
 
 	if( loading_requested || loading || loaded ) {
 		label.x = button_action->pos.x + ( button_action->pos.w / 2 );
@@ -389,11 +388,9 @@ void GameStateLoad::render() {
 			font->render(stats[slot].name, label.x, label.y, JUSTIFY_LEFT, screen, FONT_WHITE);
 
 			// level
-			ss.str("");
 			label.x = slot_pos[slot].x + level_pos.x;
 			label.y = slot_pos[slot].y + level_pos.y;		
-			ss << msg->get("character_level_class", stats[slot].level, stats[slot].character_class);
-			font->render(ss.str(), label.x, label.y, JUSTIFY_LEFT, screen, FONT_WHITE);
+			font->render(msg->get("character_level_class", stats[slot].level, msg->get(stats[slot].character_class)), label.x, label.y, JUSTIFY_LEFT, screen, FONT_WHITE);
 			
 			// map
 			label.x = slot_pos[slot].x + map_pos.x;

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -12,8 +12,6 @@
 
 StatBlock::StatBlock() {
 
-	msg = new MessageEngine(); //Cheating. Might cause a performance decrease.
-
 	name = "";
 	alive = true;
 	corpse = false;
@@ -278,34 +276,34 @@ void StatBlock::recalc() {
 	// determine class
 	// if all four stats are max, Grand Master
 	if (stat_sum >= 20)
-		character_class = msg->get("class_grand_master");
+		character_class = "class_grand_master";
 	// if three stats are max, Master
 	else if (stat_sum >= 16)
-		character_class = msg->get("class_master");
+		character_class = "class_master";
 	// if one attribute is much higher than the others, use the attribute class name
 	else if (get_physical() > get_mental()+1 && get_physical() > get_offense()+1 && get_physical() > get_defense()+1)
-		character_class = msg->get("class_physical");
+		character_class = "class_physical";
 	else if (get_mental() > get_physical()+1 && get_mental() > get_offense()+1 && get_mental() > get_defense()+1)
-		character_class = msg->get("class_mental");
+		character_class = "class_mental";
 	else if (get_offense() > get_physical()+1 && get_offense() > get_mental()+1 && get_offense() > get_defense()+1)
-		character_class = msg->get("class_offense");
+		character_class = "class_offense";
 	else if (get_defense() > get_physical()+1 && get_defense() > get_mental()+1 && get_defense() > get_offense()+1)
-		character_class = msg->get("class_defense");
+		character_class = "class_defense";
 	// if there is no dominant attribute, use the dicipline class name
 	else if (physoff > physdef && physoff > mentoff && physoff > mentdef && physoff > physment && physoff > offdef)
-		character_class = msg->get("class_physical_offense");
+		character_class = "class_physical_offense";
 	else if (physdef > physoff && physdef > mentoff && physdef > mentdef && physdef > physment && physdef > offdef)
-		character_class = msg->get("class_physical_defense");
+		character_class = "class_physical_defense";
 	else if (mentoff > physoff && mentoff > physdef && mentoff > mentdef && mentoff > physment && mentoff > offdef)
-		character_class = msg->get("class_mental_offense");
+		character_class = "class_mental_offense";
 	else if (mentdef > physoff && mentdef > physdef && mentdef > mentoff && mentdef > physment && mentdef > offdef)
-		character_class = msg->get("class_mental_defense");
+		character_class = "class_mental_defense";
 	else if (physment > physoff && physment > physdef && physment > mentoff && physment > mentdef && physment > offdef)
-		character_class = msg->get("class_physical_mental");
+		character_class = "class_physical_mental";
 	else if (offdef > physoff && offdef > physdef && offdef > mentoff && offdef > mentdef && offdef > physment)
-		character_class = msg->get("class_offense_defense");
+		character_class = "class_offense_defense";
 	// otherwise, use the generic name
-	else character_class = msg->get("class_generic");
+	else character_class = "class_generic";
 	
 }
 

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -37,8 +37,6 @@ public:
 	StatBlock();
 	~StatBlock();
 
-	MessageEngine *msg;
-
 	void load(string filename);
 	void takeDamage(int dmg);
 	void recalc();


### PR DESCRIPTION
Fixed redundant use of MessageEngine by moving the call to GameStateLoad.
