### PR TITLE
Issue #94: Implementing 'make install' target by modifying cmake config f

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,8 @@
 Project (Flare)
 cmake_minimum_required (VERSION 2.6)
 
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/..)
-
 Set (PACKAGE "FLARE")
 Set (VERSION "0.14.1")
-
 
 # Detect missing dependencies
 
@@ -108,3 +105,23 @@ If (NOT SDLMAIN_LIBRARY)
 EndIf (NOT SDLMAIN_LIBRARY)
 
 Target_Link_Libraries (flare ${SDL_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLIMAGE_LIBRARY} ${SDLTTF_LIBRARY} ${SDLMAIN_LIBRARY})
+
+
+# installing to the proper places
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/flare
+  DESTINATION games)
+install(DIRECTORY
+  "${CMAKE_CURRENT_SOURCE_DIR}/animations"
+  "${CMAKE_CURRENT_SOURCE_DIR}/enemies"
+  "${CMAKE_CURRENT_SOURCE_DIR}/engine"
+  "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
+  "${CMAKE_CURRENT_SOURCE_DIR}/images"
+  "${CMAKE_CURRENT_SOURCE_DIR}/items"
+  "${CMAKE_CURRENT_SOURCE_DIR}/maps"
+  "${CMAKE_CURRENT_SOURCE_DIR}/music"
+  "${CMAKE_CURRENT_SOURCE_DIR}/npcs"
+  "${CMAKE_CURRENT_SOURCE_DIR}/powers"
+  "${CMAKE_CURRENT_SOURCE_DIR}/quests"
+  "${CMAKE_CURRENT_SOURCE_DIR}/soundfx"
+  "${CMAKE_CURRENT_SOURCE_DIR}/tilesetdefs"
+  DESTINATION share/games/flare)

--- a/README
+++ b/README
@@ -27,7 +27,8 @@ Email     clintbellanger@gmail.com
 DEPENDENCIES
 ============
 
-To build flare you need the 1.2 Development Libraries for SDL, SDL_image, SDL_mixer, and SDL_ttf
+To build flare you need the 1.2 Development Libraries for SDL, SDL_image, SDL_mixer, and SDL_ttf.
+
 To run flare you need the equivalent 1.2 Runtime Libraries.
 
 http://www.libsdl.org/download-1.2.php
@@ -42,13 +43,20 @@ Additionally, for easy building I recommend using cmake and make.
 BUILDING WITH CMAKE
 ===================
 
-To build flare, go to the build folder (cd build) and run the following commands:
+To build flare, go to the main directory/folder and run the following commands:
 
-cmake .
-make
+	make build
+	cd build
+	cmake ..
+	make
 
-Once you're done, return to this folder and you'll see the flare executable.
+If you want the game installed system-wide, as root, install with:
 
+	make install
+
+The game will be installed into '/usr/local' by default.  You can set differet paths in the cmake step, like:
+
+	cmake -DCMAKE_INSTALL_PREFIX:STRING="/usr" ..
 
 or, BUILDING WITH g++
 =====================
@@ -65,8 +73,15 @@ g++ -I /usr/include/SDL src/*.cpp -o flare -lSDL -lSDL_image -lSDL_mixer -lSDL_t
 RUNNING FLARE
 =============
 
-Running flare from command line is straightforward in Linux:
-./flare
+If the program is installing system-wide (i.e., you typed 'make install' and it worked), you can run it just by executing the 'flare' command.
+
+If you did not perform the installation step, you should copy back the binary in 'build' to the top directory, and run it from there, like this:
+
+	cp flare ..
+	cd ..
+	./flare
+
+Also, in newer versions, the game can be launched from an icon in your main menu in your GUI environment (KDE, GNOME, etc.).
 
 If you're running flare from your operating system's gui file browser (e.g. Windows Explorer or OSX Finder), you'll want to use one of the provided launchers.  This helps the flare executable use its own working directory, so it can see all those data folders.
 


### PR DESCRIPTION
Issue #94: Implementing 'make install' target by modifying cmake config files.

You might have a different opinion about what I did with the build directory, but from my experience with other software that I package and/or use, it seems to be the most common and the best practice.  Also, you usually want to build everything out-of-tree (not putting anything in the original directory), so then cleaning is just a matter of removing the directory that you used to build the project.

Please note that the scripts to launch in OSX and Windows might need an additional step, copying the file 'flare' from build/ to the main directory.  I didn't want to do it myself for safety.
