### PR TITLE
Adding .desktop file, and configuring CMake so it installs the logo and t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ Target_Link_Libraries (flare ${SDL_LIBRARY} ${SDLMIXER_LIBRARY} ${SDLIMAGE_LIBRA
 
 # installing to the proper places
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/flare
-  DESTINATION games)
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/games)
 install(DIRECTORY
   "${CMAKE_CURRENT_SOURCE_DIR}/animations"
   "${CMAKE_CURRENT_SOURCE_DIR}/enemies"
@@ -124,4 +124,11 @@ install(DIRECTORY
   "${CMAKE_CURRENT_SOURCE_DIR}/quests"
   "${CMAKE_CURRENT_SOURCE_DIR}/soundfx"
   "${CMAKE_CURRENT_SOURCE_DIR}/tilesetdefs"
-  DESTINATION share/games/flare)
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/games/flare)
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/distribution/flare.desktop"
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/art/logo/flare_logo.svg"
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps
+  RENAME flare.svg)

--- a/distribution/flare.desktop
+++ b/distribution/flare.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Flare
+GenericName=Flare (Action Role-Playing Game)
+Comment=A single player, 2D-isometric, action Role-Playing Game
+TryExec=/usr/games/flare
+Exec=/usr/games/flare
+Categories=Game;RolePlaying
+Icon=flare.svg
+Terminal=false


### PR DESCRIPTION
Adding .desktop file, and configuring CMake so it installs the logo and the new .desktop file, for a nice entry in UNIX GUI menus.

The use of the dir "distribution" is arguable, it doesn't seem to be a consensus in projects that I know.  But I thought of that name because it did not seem to fit in any of the existing directories; and because I thought that other information can be put there, like the logo, or scripts to create packages for the different operating systems, or even the current Launcher\* scripts.
