### PR TITLE
Added support for translating enemy names. Made MessageEngine global.

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -23,9 +23,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "Avatar.h"
 
-Avatar::Avatar(PowerManager *_powers, InputState *_inp, MapIso *_map, MessageEngine *_msg) : Entity(_map), powers(_powers), inp(_inp) {
+Avatar::Avatar(PowerManager *_powers, InputState *_inp, MapIso *_map) : Entity(_map), powers(_powers), inp(_inp) {
 	
-	msg = _msg;
 	init();
 	
 	// default hero animation data

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -53,7 +53,6 @@ private:
 	
 	PowerManager *powers;
 	InputState *inp;
-	MessageEngine *msg;
 
 	bool lockSwing;
 	bool lockCast;
@@ -72,7 +71,7 @@ private:
 	string img_off;
 
 public:
-	Avatar(PowerManager *_powers, InputState *_inp, MapIso *_map, MessageEngine *_msg);
+	Avatar(PowerManager *_powers, InputState *_inp, MapIso *_map);
 	~Avatar();
 	
 	void init();

--- a/src/CampaignManager.cpp
+++ b/src/CampaignManager.cpp
@@ -23,9 +23,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "CampaignManager.h"
 
-CampaignManager::CampaignManager(MessageEngine *_msg) {
-
-	msg = _msg;
+CampaignManager::CampaignManager() {
 
 	drop_stack.item = 0;
 	drop_stack.quantity = 0;

--- a/src/CampaignManager.h
+++ b/src/CampaignManager.h
@@ -34,11 +34,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 const int MAX_STATUS = 1024;
 
 class CampaignManager {
-private:
-	MessageEngine *msg;
-
 public:
-	CampaignManager(MessageEngine *_msg);
+	CampaignManager();
 	~CampaignManager();
 	
 	void clearAll();

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -17,11 +17,10 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "GameState.h"
 
-GameState::GameState(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) {
+GameState::GameState(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) {
 	screen = _screen;
 	inp = _inp;
 	font = _font;
-	msg = _msg;
 
 	requestedGameState = NULL;
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -27,7 +27,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 class GameState {
 public:
-	GameState(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg);
+	GameState(SDL_Surface *_screen, InputState *_inp, FontEngine *_font);
 
 	virtual void logic();
 	virtual void render();
@@ -40,7 +40,6 @@ protected:
 	SDL_Surface *screen;
 	InputState *inp;
 	FontEngine *font;
-	MessageEngine *msg;
 
 	GameState* requestedGameState;	
 

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -24,8 +24,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateNew.h"
 #include "MenuConfirm.h"
 
-GameStateLoad::GameStateLoad(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) : GameState(_screen, _inp, _font, _msg) {
-	items = new ItemDatabase(screen, font, msg);
+GameStateLoad::GameStateLoad(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) : GameState(_screen, _inp, _font) {
+	items = new ItemDatabase(screen, font);
 	portrait = NULL;
 	loading_requested = false;
 	loading = false;
@@ -267,7 +267,7 @@ void GameStateLoad::logic() {
 		current_frame = (63 - frame_ticker) / 8;
 
 	if (button_exit->checkClick()) {
-		requestedGameState = new GameStateTitle(screen, inp, font, msg);
+		requestedGameState = new GameStateTitle(screen, inp, font);
 	}
 	
 	if(loading_requested) {
@@ -279,7 +279,7 @@ void GameStateLoad::logic() {
 	if (button_action->checkClick()) {
 		if (stats[selected_slot].name == "") {
 			// create a new game
-			GameStateNew* newgame = new GameStateNew(screen, inp, font, msg);
+			GameStateNew* newgame = new GameStateNew(screen, inp, font);
 			newgame->game_slot = selected_slot + 1;
 			requestedGameState = newgame;
 		}
@@ -334,7 +334,7 @@ void GameStateLoad::logic() {
 
 void GameStateLoad::logicLoading() {
 	// load an existing game
-	GameStatePlay* play = new GameStatePlay(screen, inp, font, msg);
+	GameStatePlay* play = new GameStatePlay(screen, inp, font);
 	play->resetGame();
 	play->game_slot = selected_slot + 1;
 	play->loadGame();

--- a/src/GameStateLoad.h
+++ b/src/GameStateLoad.h
@@ -85,7 +85,7 @@ private:
 	int frame_ticker;
 	
 public:
-	GameStateLoad(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg);
+	GameStateLoad(SDL_Surface *_screen, InputState *_inp, FontEngine *_font);
 	~GameStateLoad();
 
 	void logic();

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -26,7 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateLoad.h"
 #include "GameStatePlay.h"
 
-GameStateNew::GameStateNew(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) : GameState(_screen, _inp, _font, _msg) {
+GameStateNew::GameStateNew(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) : GameState(_screen, _inp, _font) {
 	game_slot = 0;
 	option_count = 0;
 	current_option = 0;
@@ -124,12 +124,12 @@ void GameStateNew::logic() {
 	}
 
 	if (button_exit->checkClick()) {
-		requestedGameState = new GameStateLoad(screen, inp, font, msg);
+		requestedGameState = new GameStateLoad(screen, inp, font);
 	}
 	
 	if (button_create->checkClick()) {
 		// start the new game
-		GameStatePlay* play = new GameStatePlay(screen, inp, font, msg);
+		GameStatePlay* play = new GameStatePlay(screen, inp, font);
 		play->pc->stats.base = base[current_option];
 		play->pc->stats.head = head[current_option];
 		play->pc->stats.portrait = portrait[current_option];

--- a/src/GameStateNew.h
+++ b/src/GameStateNew.h
@@ -65,7 +65,7 @@ private:
 	WidgetInput *input_name;
 
 public:
-	GameStateNew(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg);
+	GameStateNew(SDL_Surface *_screen, InputState *_inp, FontEngine *_font);
 	~GameStateNew();
 	void logic();
 	void render();

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -26,7 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameState.h"
 #include "GameStateTitle.h"
 
-GameStatePlay::GameStatePlay(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) : GameState(screen, inp, font, msg) {
+GameStatePlay::GameStatePlay(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) : GameState(screen, inp, font) {
 
 	hasMusic = true;
 	//Mix_HaltMusic(); // maybe not needed? playing new music should auto halt previous music
@@ -34,22 +34,21 @@ GameStatePlay::GameStatePlay(SDL_Surface *_screen, InputState *_inp, FontEngine 
 	// shared resources from GameSwitcher
 	screen = _screen;
 	inp = _inp;
-	msg = _msg;
 	
 	// GameEngine scope variables
 	npc_id = -1;
 	game_slot = 0;
 
 	// construct gameplay objects
-	powers = new PowerManager(msg);
+	powers = new PowerManager();
 	font = _font;
-	camp = new CampaignManager(msg);
+	camp = new CampaignManager();
 	map = new MapIso(_screen, camp, _inp, font);
-	pc = new Avatar(powers, _inp, map, msg);
+	pc = new Avatar(powers, _inp, map);
 	enemies = new EnemyManager(powers, map);
 	hazards = new HazardManager(powers, pc, enemies);
-	menu = new MenuManager(powers, _screen, _inp, font, &pc->stats, camp, msg);
-	loot = new LootManager(menu->items, menu->tip, enemies, map, msg);
+	menu = new MenuManager(powers, _screen, _inp, font, &pc->stats, camp);
+	loot = new LootManager(menu->items, menu->tip, enemies, map);
 	npcs = new NPCManager(map, menu->tip, loot, menu->items);
 	quests = new QuestLog(camp, menu->log);
 
@@ -203,7 +202,7 @@ void GameStatePlay::checkCancel() {
 	if (menu->requestingExit()) {
 		saveGame();
 		Mix_HaltMusic();
-		requestedGameState = new GameStateTitle(screen, inp, font, msg);
+		requestedGameState = new GameStateTitle(screen, inp, font);
 	}
 
 	// if user closes the window

--- a/src/GameStatePlay.h
+++ b/src/GameStatePlay.h
@@ -62,7 +62,6 @@ private:
 	NPCManager *npcs;
 	CampaignManager *camp;
 	QuestLog *quests;
-	MessageEngine *msg;
 	
 	bool restrictPowerUse();
 	void checkEnemyFocus();
@@ -78,7 +77,7 @@ private:
 	int npc_id;
 	
 public:
-	GameStatePlay(SDL_Surface *screen, InputState *inp, FontEngine *font, MessageEngine *msg);
+	GameStatePlay(SDL_Surface *screen, InputState *inp, FontEngine *font);
 	~GameStatePlay();
 
 	void logic();

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -18,7 +18,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateLoad.h"
 #include "GameStateTitle.h"
 
-GameStateTitle::GameStateTitle(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) : GameState(_screen, _inp, _font, _msg) {
+GameStateTitle::GameStateTitle(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) : GameState(_screen, _inp, _font) {
 
 	exit_game = false;
 	load_game = false;
@@ -60,7 +60,7 @@ void GameStateTitle::loadGraphics() {
 void GameStateTitle::logic() {
 
 	if (button_play->checkClick()) {
-		requestedGameState = new GameStateLoad(screen, inp, font, msg);
+		requestedGameState = new GameStateLoad(screen, inp, font);
 	}
 	
 	if (button_exit->checkClick()) {

--- a/src/GameStateTitle.h
+++ b/src/GameStateTitle.h
@@ -31,7 +31,7 @@ private:
 	WidgetLabel *label_version;
 	
 public:
-	GameStateTitle(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg);
+	GameStateTitle(SDL_Surface *_screen, InputState *_inp, FontEngine *_font);
 	~GameStateTitle();
 	void loadGraphics();
 	void logic();

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -32,15 +32,14 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateTitle.h"
 #include "GameStateLoad.h"
 
-GameSwitcher::GameSwitcher(SDL_Surface *_screen, InputState *_inp, MessageEngine *_msg) {
+GameSwitcher::GameSwitcher(SDL_Surface *_screen, InputState *_inp) {
 	inp = _inp;
 	screen = _screen;
-	msg = _msg;
 		
 	font = new FontEngine();
 
 	// The initial state is the title screen
-	currentState = new GameStateTitle(screen, inp, font, msg);
+	currentState = new GameStateTitle(screen, inp, font);
 	
 	done = false;
 	music = NULL;

--- a/src/GameSwitcher.h
+++ b/src/GameSwitcher.h
@@ -52,12 +52,11 @@ private:
 	InputState *inp;
 	FontEngine *font;
 	Mix_Music *music;
-	MessageEngine *msg;
 	
 	GameState *currentState;
 	
 public:
-	GameSwitcher(SDL_Surface *_screen, InputState *_inp, MessageEngine *_msg);
+	GameSwitcher(SDL_Surface *_screen, InputState *_inp);
 	void loadMusic();
 	void logic();
 	void render();

--- a/src/ItemDatabase.cpp
+++ b/src/ItemDatabase.cpp
@@ -22,10 +22,9 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "ItemDatabase.h"
 #include "FileParser.h"
 
-ItemDatabase::ItemDatabase(SDL_Surface *_screen, FontEngine *_font, MessageEngine *_msg) {
+ItemDatabase::ItemDatabase(SDL_Surface *_screen, FontEngine *_font) {
 	screen = _screen;
 	font = _font;
-	msg = _msg;
 	
 	items = new Item[MAX_ITEM_ID];
 	

--- a/src/ItemDatabase.h
+++ b/src/ItemDatabase.h
@@ -142,13 +142,12 @@ private:
 	SDL_Surface *icons32;
 	SDL_Surface *icons64; // item db is the only module that currently uses the 64px icons
 	FontEngine *font;
-	MessageEngine *msg;
 	SDL_Rect src;
 	SDL_Rect dest;
 	Mix_Chunk *sfx[12];
 
 public:
-	ItemDatabase(SDL_Surface *_screen, FontEngine *_font, MessageEngine *_msg);
+	ItemDatabase(SDL_Surface *_screen, FontEngine *_font);
 	~ItemDatabase();
 	void load();
 	void loadSounds();

--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -23,12 +23,11 @@ FLARE.  If not, see http://www.gnu.org/licenses/
  
 #include "LootManager.h"
  
-LootManager::LootManager(ItemDatabase *_items, MenuTooltip *_tip, EnemyManager *_enemies, MapIso *_map, MessageEngine *_msg) {
+LootManager::LootManager(ItemDatabase *_items, MenuTooltip *_tip, EnemyManager *_enemies, MapIso *_map) {
 	items = _items;
 	tip = _tip;
 	enemies = _enemies; // we need to be able to read loot state when creatures die
 	map = _map; // we need to be able to read loot that drops from map containers
-	msg = _msg;
 	
 	tooltip_margin = 32; // pixels between loot drop center and label
 	

--- a/src/LootManager.h
+++ b/src/LootManager.h
@@ -61,7 +61,6 @@ private:
 	MenuTooltip *tip;
 	EnemyManager *enemies;
 	MapIso *map;
-	MessageEngine *msg;
 
 	// functions
 	void loadGraphics();
@@ -92,7 +91,7 @@ private:
 	int anim_loot_duration;
 	
 public:
-	LootManager(ItemDatabase *_items, MenuTooltip *_tip, EnemyManager *_enemies, MapIso *_map, MessageEngine *_msg);
+	LootManager(ItemDatabase *_items, MenuTooltip *_tip, EnemyManager *_enemies, MapIso *_map);
 	~LootManager();
 
 	void handleNewMap();

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -23,14 +23,13 @@ FLARE.  If not, see http://www.gnu.org/licenses/
  
 #include "MenuActionBar.h"
 
-MenuActionBar::MenuActionBar(SDL_Surface *_screen, FontEngine *_font, InputState *_inp, PowerManager *_powers, StatBlock *_hero, SDL_Surface *_icons, MessageEngine *_msg) {
+MenuActionBar::MenuActionBar(SDL_Surface *_screen, FontEngine *_font, InputState *_inp, PowerManager *_powers, StatBlock *_hero, SDL_Surface *_icons) {
 	screen = _screen;
 	font = _font;
 	inp = _inp;
 	powers = _powers;
 	hero = _hero;
 	icons = _icons;
-	msg = _msg;
 	
 	src.x = 0;
 	src.y = 0;

--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -53,7 +53,6 @@ private:
 	PowerManager *powers;
 	InputState *inp;
 	FontEngine *font;
-	MessageEngine *msg;
 	SDL_Rect src;
 	SDL_Rect label_src;
 	
@@ -62,7 +61,7 @@ private:
 	
 public:
 
-	MenuActionBar(SDL_Surface *_screen, FontEngine *_font, InputState *_inp, PowerManager *_powers, StatBlock *hero, SDL_Surface *icons, MessageEngine *_msg);
+	MenuActionBar(SDL_Surface *_screen, FontEngine *_font, InputState *_inp, PowerManager *_powers, StatBlock *hero, SDL_Surface *icons);
 	~MenuActionBar();
 	void loadGraphics();
 	void renderIcon(int icon_id, int x, int y);

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -21,12 +21,11 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuCharacter.h"
 
-MenuCharacter::MenuCharacter(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, MessageEngine *_msg) {
+MenuCharacter::MenuCharacter(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats) {
 	screen = _screen;
 	inp = _inp;
 	font = _font;
 	stats = _stats;
-	msg = _msg;
 	
 	visible = false;
 

--- a/src/MenuCharacter.h
+++ b/src/MenuCharacter.h
@@ -108,7 +108,6 @@ private:
 	InputState *inp;
 	FontEngine *font;
 	StatBlock *stats;
-	MessageEngine *msg;
 
 	SDL_Surface *background;
 	SDL_Surface *proficiency;
@@ -123,7 +122,7 @@ private:
 	int bonusColor(int stat);
 	
 public:
-	MenuCharacter(SDL_Surface *screen, InputState *inp, FontEngine *font, StatBlock *stats, MessageEngine *_msg);
+	MenuCharacter(SDL_Surface *screen, InputState *inp, FontEngine *font, StatBlock *stats);
 	~MenuCharacter();
 	void logic();
 	void render();

--- a/src/MenuEnemy.cpp
+++ b/src/MenuEnemy.cpp
@@ -23,10 +23,9 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuEnemy.h"
 
-MenuEnemy::MenuEnemy(SDL_Surface *_screen, FontEngine *_font, MessageEngine *_msg) {
+MenuEnemy::MenuEnemy(SDL_Surface *_screen, FontEngine *_font) {
 	screen = _screen;
 	font = _font;
-	msg = _msg;
 	loadGraphics();
 	enemy = NULL;
 	timeout = 0;

--- a/src/MenuEnemy.h
+++ b/src/MenuEnemy.h
@@ -40,11 +40,10 @@ class MenuEnemy {
 private:
 	SDL_Surface *screen;
 	FontEngine *font;
-	MessageEngine *msg;
 	SDL_Surface *background;
 	SDL_Surface *bar_hp;
 public:
-	MenuEnemy(SDL_Surface *_screen, FontEngine *_font, MessageEngine *_msg);
+	MenuEnemy(SDL_Surface *_screen, FontEngine *_font);
 	~MenuEnemy();
 	Enemy *enemy;
 	void loadGraphics();

--- a/src/MenuExit.cpp
+++ b/src/MenuExit.cpp
@@ -21,8 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuExit.h"
 
-MenuExit::MenuExit(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) : Menu(_screen, inp = _inp, _font) {
-	msg = _msg;
+MenuExit::MenuExit(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) : Menu(_screen, inp = _inp, _font) {
 
 	exitClicked = false;
 

--- a/src/MenuExit.h
+++ b/src/MenuExit.h
@@ -30,7 +30,6 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 class MenuExit : public Menu {
 protected:
 	void loadGraphics();
-	MessageEngine *msg;
 
 	WidgetButton *buttonExit;
 	WidgetButton *buttonClose;
@@ -38,7 +37,7 @@ protected:
 	bool exitClicked;
 
 public:
-	MenuExit(SDL_Surface*, InputState*, FontEngine*, MessageEngine *msg);
+	MenuExit(SDL_Surface*, InputState*, FontEngine*);
 	~MenuExit();
 
 	void logic();

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -21,14 +21,13 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuInventory.h"
 
-MenuInventory::MenuInventory(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, ItemDatabase *_items, StatBlock *_stats, PowerManager *_powers, MessageEngine *_msg) {
+MenuInventory::MenuInventory(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, ItemDatabase *_items, StatBlock *_stats, PowerManager *_powers) {
 	screen = _screen;
 	inp = _inp;
 	font = _font;
 	items = _items;
 	stats = _stats;
 	powers = _powers;
-	msg = _msg;
 	
 	visible = false;
 	loadGraphics();

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -60,7 +60,6 @@ private:
 	FontEngine *font;
 	StatBlock *stats;
 	PowerManager *powers;
-	MessageEngine *msg;
 
 	void loadGraphics();
 	int areaOver(Point mouse);
@@ -70,7 +69,7 @@ private:
 	WidgetButton *closeButton;
 	
 public:
-	MenuInventory(SDL_Surface *screen, InputState *inp, FontEngine *font, ItemDatabase *items, StatBlock *stats, PowerManager *powers, MessageEngine *_msg);
+	MenuInventory(SDL_Surface *screen, InputState *inp, FontEngine *font, ItemDatabase *items, StatBlock *stats, PowerManager *powers);
 	~MenuInventory();
 	void logic();
 	void render();

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -21,11 +21,10 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuLog.h"
 
-MenuLog::MenuLog(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, MessageEngine *_msg) {
+MenuLog::MenuLog(SDL_Surface *_screen, InputState *_inp, FontEngine *_font) {
 	screen = _screen;
 	inp = _inp;
 	font = _font;
-	msg = _msg;
 
 	visible = false;
 	

--- a/src/MenuLog.h
+++ b/src/MenuLog.h
@@ -45,7 +45,6 @@ private:
 	SDL_Surface *screen;
 	InputState *inp;
 	FontEngine *font;
-	MessageEngine *msg;
 
 	SDL_Surface *background;
 	SDL_Surface *tab_active;
@@ -64,7 +63,7 @@ private:
 	int paragraph_spacing;
 	
 public:
-	MenuLog(SDL_Surface *screen, InputState *inp, FontEngine *font, MessageEngine *_msg);
+	MenuLog(SDL_Surface *screen, InputState *inp, FontEngine *font);
 	~MenuLog();
 
 	void logic();

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -21,7 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuManager.h"
 
-MenuManager::MenuManager(PowerManager *_powers, SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, CampaignManager *_camp, MessageEngine *_msg) {
+MenuManager::MenuManager(PowerManager *_powers, SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, CampaignManager *_camp) {
 	powers = _powers;
 	screen = _screen;
 	inp = _inp;
@@ -29,26 +29,25 @@ MenuManager::MenuManager(PowerManager *_powers, SDL_Surface *_screen, InputState
 	stats = _stats;
 	powers = _powers;
 	camp = _camp;
-	msg = _msg;
 
 	loadIcons();
 
-	items = new ItemDatabase(screen, font, msg);
+	items = new ItemDatabase(screen, font);
 
-	chr = new MenuCharacter(screen, inp, font, stats, msg);
-	inv = new MenuInventory(screen, inp, font, items, stats, powers, msg);
-	pow = new MenuPowers(screen, inp, font, stats, powers, msg);
-	log = new MenuLog(screen, inp, font, msg);
+	chr = new MenuCharacter(screen, inp, font, stats);
+	inv = new MenuInventory(screen, inp, font, items, stats, powers);
+	pow = new MenuPowers(screen, inp, font, stats, powers);
+	log = new MenuLog(screen, inp, font);
 	hudlog = new MenuHUDLog(screen, font);
-	act = new MenuActionBar(screen, font, inp, powers, stats, icons, msg);
+	act = new MenuActionBar(screen, font, inp, powers, stats, icons);
 	hpmp = new MenuHPMP(screen, font);
 	tip = new MenuTooltip(font, screen);
 	mini = new MenuMiniMap(screen);
 	xp = new MenuExperience(screen, font);
-	enemy = new MenuEnemy(screen, font, msg);
-	vendor = new MenuVendor(screen, inp, font, items, stats, msg);
+	enemy = new MenuEnemy(screen, font);
+	vendor = new MenuVendor(screen, inp, font, items, stats);
 	talker = new MenuTalker(screen, inp, font, camp);
-	exit = new MenuExit(screen, inp, font, msg);
+	exit = new MenuExit(screen, inp, font);
 
 	pause = false;
 	dragging = false;

--- a/src/MenuManager.h
+++ b/src/MenuManager.h
@@ -64,7 +64,6 @@ private:
 	FontEngine *font;
 	SDL_Surface *screen;
 	CampaignManager *camp;
-	MessageEngine *msg;
 
 	bool key_lock;
 	void loadSounds();
@@ -78,7 +77,7 @@ private:
 	bool done;
 	
 public:
-	MenuManager(PowerManager *powers, SDL_Surface *screen, InputState *inp, FontEngine *font, StatBlock *stats, CampaignManager *camp, MessageEngine *_msg);
+	MenuManager(PowerManager *powers, SDL_Surface *screen, InputState *inp, FontEngine *font, StatBlock *stats, CampaignManager *camp);
 	~MenuManager();
 	void logic();
 	void render();

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -21,13 +21,12 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuPowers.h"
 
-MenuPowers::MenuPowers(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, PowerManager *_powers, MessageEngine *_msg) {
+MenuPowers::MenuPowers(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, PowerManager *_powers) {
 	screen = _screen;
 	inp = _inp;
 	font = _font;
 	stats = _stats;
 	powers = _powers;
-	msg = _msg;
 	
 	visible = false;
 	loadGraphics();

--- a/src/MenuPowers.h
+++ b/src/MenuPowers.h
@@ -45,7 +45,6 @@ private:
 	FontEngine *font;
 	StatBlock *stats;
 	PowerManager *powers;
-	MessageEngine *msg;
 
 	SDL_Surface *background;
 	SDL_Surface *powers_step;
@@ -56,7 +55,7 @@ private:
 	void displayBuild(int value, int x);
 
 public:
-	MenuPowers(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, PowerManager *_powers, MessageEngine *_msg);
+	MenuPowers(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, StatBlock *_stats, PowerManager *_powers);
 	~MenuPowers();
 	void logic();
 	void render();

--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -21,13 +21,12 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "MenuVendor.h"
 
-MenuVendor::MenuVendor(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, ItemDatabase *_items, StatBlock *_stats, MessageEngine *_msg) {
+MenuVendor::MenuVendor(SDL_Surface *_screen, InputState *_inp, FontEngine *_font, ItemDatabase *_items, StatBlock *_stats) {
 	screen = _screen;
 	inp = _inp;
 	font = _font;
 	items = _items;
 	stats = _stats;
-	msg = _msg;
 
 	int offset_y = (VIEW_H - 416)/2;
 

--- a/src/MenuVendor.h
+++ b/src/MenuVendor.h
@@ -46,7 +46,6 @@ private:
 	FontEngine *font;
 	StatBlock *stats;
 	InputState *inp;
-	MessageEngine *msg;
 	WidgetButton *closeButton;
 
 	void loadGraphics();
@@ -54,7 +53,7 @@ private:
 	MenuItemStorage stock; // items the vendor currently has in stock
 
 public:
-	MenuVendor(SDL_Surface *screen, InputState *_inp, FontEngine *font, ItemDatabase *items, StatBlock *stats, MessageEngine *msg);
+	MenuVendor(SDL_Surface *screen, InputState *_inp, FontEngine *font, ItemDatabase *items, StatBlock *stats);
 	~MenuVendor();
 
 	NPC *npc;

--- a/src/MessageEngine.cpp
+++ b/src/MessageEngine.cpp
@@ -28,6 +28,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <sstream>
 #include <iostream>
 
+MessageEngine *msg;
+
 MessageEngine::MessageEngine() {
 	GetText infile;
 	if (infile.open(PATH_DATA + "languages/engine." + LANGUAGE + ".po")) {

--- a/src/MessageEngine.h
+++ b/src/MessageEngine.h
@@ -50,4 +50,9 @@ public:
 
 };
 
+// The MessageEngine is initialized once,
+// never changed, and used everywhere, so
+// it works nicely as a global variable.
+extern MessageEngine *msg;
+
 #endif

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -25,8 +25,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 /**
  * PowerManager constructor
  */
-PowerManager::PowerManager(MessageEngine *_msg) {
-	msg = _msg;
+PowerManager::PowerManager() {
 
 	gfx_count = 0;
 	sfx_count = 0;

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -284,13 +284,12 @@ private:
 	bool single(int powernum, StatBlock *src_stats, Point target);
 
 public:
-	PowerManager(MessageEngine *_msg);
+	PowerManager();
 	~PowerManager();
 
 	void handleNewMap(MapCollision *_collider);
 	bool activate(int power_index, StatBlock *src_stats, Point target);
 
-    MessageEngine *msg;
 	StatBlock *src_stats;
 	Power powers[POWER_COUNT];
 	queue<Hazard *> hazards; // output; read by HazardManager

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -133,7 +133,7 @@ void StatBlock::load(string filename) {
 		while (infile.next()) {
 			if (isInt(infile.val)) num = atoi(infile.val.c_str());
 			
-			if (infile.key == "name") name = infile.val;
+			if (infile.key == "name") name = msg->get(infile.val);
 			else if (infile.key == "sfx_prefix") sfx_prefix = infile.val;
 			else if (infile.key == "gfx_prefix") gfx_prefix = infile.val;
 			

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <fstream>
 #include "Settings.h"
 #include "Utils.h"
+#include "MessageEngine.h"
 
 using namespace std;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,6 @@ using namespace std;
 SDL_Surface *screen;
 InputState *inps;
 GameSwitcher *gswitch;
-MessageEngine *msg;
 
 static void init() {
 
@@ -48,9 +47,6 @@ static void init() {
 		flags = flags | SDL_HWSURFACE;
 	else
 		flags = flags | SDL_SWSURFACE;
-	
-	// Load Messages
-	msg = new MessageEngine();
 
 	// Create window
 	screen = SDL_SetVideoMode (VIEW_W, VIEW_H, 0, flags);
@@ -74,6 +70,10 @@ static void init() {
 	  }
 	  SDL_JoystickOpen(0);
 	}
+
+    // setup MessageEngine here instead of below so we can initialize window title
+    msg = new MessageEngine();
+
 	const char* title = msg->get("Flare").c_str();
 	SDL_WM_SetCaption(title, title);
 	
@@ -83,7 +83,7 @@ static void init() {
 	/* Shared game units setup */
 	mods = new ModManager();
 	inps = new InputState();
-	gswitch = new GameSwitcher(screen, inps, msg);
+	gswitch = new GameSwitcher(screen, inps);
 }
 
 static void mainLoop () {


### PR DESCRIPTION
Made MessageEngine a global variable and added support for translating enemy names.

It was nice to see that setting MessageEngine as a global variable simplifies things a TON.
