### PR TITLE
Fixing variable types to match properly the ones that they are assined/co

### DIFF
--- a/src/EnemyGroupManager.cpp
+++ b/src/EnemyGroupManager.cpp
@@ -46,7 +46,7 @@ void EnemyGroupManager::generate()
 	string dir = PATH_DATA + string("enemies");
 	vector<string> files;
 	getFileList(dir, ".txt", files);
-	for (int i = 0; i < files.size(); ++i) {
+	for (size_t i = 0; i < files.size(); ++i) {
 		parseEnemyFileAndStore(dir, files[i]);
 	}
 }
@@ -107,7 +107,7 @@ Enemy_Level EnemyGroupManager::getRandomEnemy(const std::string& category, int m
 			}
 
 			// do add, the given number of times
-			for (int i = 0; i < add_times; ++i) {
+			for (int j = 0; j < add_times; ++j) {
 				enemyCandidates.push_back(new_enemy);
 			}
 		}

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -94,7 +94,7 @@ string FileParser::nextValue() {
 		return ""; // not found
 	}
 	string s;
-	int seppos = val.find_first_of(',');
+	size_t seppos = val.find_first_of(',');
 	if (seppos == string::npos) {
 		s = val;
 		val = "";

--- a/src/MapIso.cpp
+++ b/src/MapIso.cpp
@@ -148,11 +148,11 @@ void MapIso::push_enemy_group(Map_Group g) {
 	}
 	//remove locations that already have an enemy on them
 	Map_Enemy test_enemy;
-	for (int i = 0; i < enemies.size(); i++) {
+	for (size_t i = 0; i < enemies.size(); i++) {
 		test_enemy = enemies.front();
 		enemies.pop();
 		enemies.push(test_enemy);
-		for (int j = 0; j < valid_locations.size(); j++) {
+		for (size_t j = 0; j < valid_locations.size(); j++) {
 			if ( (test_enemy.pos.x == valid_locations.at(j).x) && (test_enemy.pos.y == valid_locations.at(j).y) ) {
 				valid_locations.erase(valid_locations.begin() + j);
 			}

--- a/src/MessageEngine.cpp
+++ b/src/MessageEngine.cpp
@@ -58,7 +58,7 @@ string MessageEngine::get(string key) {
 string MessageEngine::get(string key, int i) {
 	string msg = messages[key];
 	if (msg == "") msg = key;
-	int index = msg.find("%d");
+	size_t index = msg.find("%d");
 	if (index != string::npos) msg = msg.replace(index, 2, str(i));
 	return msg;
 }
@@ -66,7 +66,7 @@ string MessageEngine::get(string key, int i) {
 string MessageEngine::get(string key, string s) {
 	string msg = messages[key];
 	if (msg == "") msg = key;
-	int index = msg.find("%s");
+	size_t index = msg.find("%s");
 	if (index != string::npos) msg = msg.replace(index, 2, s);
 	return msg;
 }
@@ -74,7 +74,7 @@ string MessageEngine::get(string key, string s) {
 string MessageEngine::get(string key, int i, string s) {
 	string msg = messages[key];
 	if (msg == "") msg = key;
-	int index = msg.find("%d");
+	size_t index = msg.find("%d");
 	if (index != string::npos) msg = msg.replace(index, 2, str(i));
 	index = msg.find("%s");
 	if (index != string::npos) msg = msg.replace(index, 2, s);
@@ -84,7 +84,7 @@ string MessageEngine::get(string key, int i, string s) {
 string MessageEngine::get(string key, int i, int j) {
 	string msg = messages[key];
 	if (msg == "") msg = key;
-	int index = msg.find("%d");
+	size_t index = msg.find("%d");
 	if (index != string::npos) msg = msg.replace(index, 2, str(i));
 	index = msg.find("%d");
 	if (index != string::npos) msg = msg.replace(index, 2, str(j));

--- a/src/UtilsFileSystem.cpp
+++ b/src/UtilsFileSystem.cpp
@@ -81,7 +81,7 @@ int getFileList(std::string dir, std::string ext, std::vector<std::string> &file
         return errno;
     }
 	
-	int extlen = ext.length();
+	size_t extlen = ext.length();
     while ((dirp = readdir(dp)) != NULL) {
 	//	if(dirp->d_type == 0x8) { //0x4 for directories, 0x8 for files
 		std::string filename = std::string(dirp->d_name);

--- a/src/UtilsParsing.cpp
+++ b/src/UtilsParsing.cpp
@@ -117,13 +117,13 @@ string trim(string s, char c) {
 }
 
 string parse_section_title(string s) {
-	unsigned int bracket = s.find_first_of(']');
+	size_t bracket = s.find_first_of(']');
 	if (bracket == string::npos) return ""; // not found
 	return s.substr(1, bracket-1);
 }
 
 void parse_key_pair(string s, string &key, string &val) {
-	unsigned int separator = s.find_first_of('=');
+	size_t separator = s.find_first_of('=');
 	if (separator == string::npos) {
 		key = "";
 		val = "";
@@ -142,7 +142,7 @@ void parse_key_pair(string s, string &key, string &val) {
  * This is basically a really lazy "split" replacement
  */
 int eatFirstInt(string &s, char separator) {
-	int seppos = s.find_first_of(separator);
+	size_t seppos = s.find_first_of(separator);
 	if (seppos == string::npos) {
 		s = "";
 		return 0; // not found
@@ -153,7 +153,7 @@ int eatFirstInt(string &s, char separator) {
 }
 
 unsigned short eatFirstHex(string &s, char separator) {
-	int seppos = s.find_first_of(separator);
+	size_t seppos = s.find_first_of(separator);
 	if (seppos == string::npos) {
 		s = "";
 		return 0; // not found
@@ -164,7 +164,7 @@ unsigned short eatFirstHex(string &s, char separator) {
 }
 
 string eatFirstString(string &s, char separator) {
-	int seppos = s.find_first_of(separator);
+	size_t seppos = s.find_first_of(separator);
 	if (seppos == string::npos) return ""; // not found
 	string outs = s.substr(0, seppos);
 	s = s.substr(seppos+1, s.length());


### PR DESCRIPTION
Fixing variable types to match properly the ones that they are assined/compared to.  Some are somewhat serious in 64 bit architectures, e.g. comparisons always rendering false, as in 'src/UtilsParsing.cpp:121:25: warning: comparison is always false due to limited range of data type [-Wtype-limits]'.  This avoids compiler warnings, too.
