### PR TITLE
Customizable install dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 set(BINDIR  "games"             CACHE STRING "where to install game binary")
 set(DATADIR "share/games/flare" CACHE STRING "where to install game data")
 
+add_definitions(-DDATA_INSTALL_DIR="${CMAKE_INSTALL_PREFIX}/${DATADIR}")
+
 # Detect missing dependencies
 
 Find_Package (SDL REQUIRED)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -171,6 +171,11 @@ void setPaths() {
 			pathtest = eatFirstString(pathlist,':');
 		}
 	}
+
+#if defined DATA_INSTALL_DIR
+	PATH_DATA = DATA_INSTALL_DIR "/";
+	if (dirExists(PATH_DATA)) return; // NOTE: early exit
+#endif
 	
 	// check /usr/local/share/flare/ and /usr/share/flare/ next
 	PATH_DATA = "/usr/local/share/" + engine_folder + "/";


### PR DESCRIPTION
FreeBSD and AFAIK some Linux distros don't use dedicated games/ for binaries and share/games for data, so don't hardcode and make them customizable.
