### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@ Set (VERSION "0.15")
 
 # Default definitions
 add_definitions(-Wall -Wextra -Wno-unused -Wshadow -Woverloaded-virtual)
-if (NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release")
-endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   set(CMAKE_CXX_FLAGS_RELEASE "-O2 -g0")
 elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")


### PR DESCRIPTION
Don't override CMAKE_CXX_FLAGS, which may be defined by user or ports system; don't force build type for the same reason.
