### PR TITLE
Fix enemy groups not spawning.

### DIFF
--- a/src/EnemyGroupManager.cpp
+++ b/src/EnemyGroupManager.cpp
@@ -56,7 +56,7 @@ void EnemyGroupManager::generate() {
 
 void EnemyGroupManager::parseEnemyFileAndStore(const string& dir, const string& filename) {
 	FileParser infile;
-	if (infile.open(mods->locate(dir + "/" + filename))) {
+	if (infile.open(mods->locate("/enemies/" + filename))) {
 		Enemy_Level new_enemy;
 		new_enemy.type = filename.substr(0, filename.length()-4); //removes the ".txt" from the filename
 		while (infile.next()) {


### PR DESCRIPTION
I had an issue where enemy groups wouldn't spawn. After a bit of digging, I found that the directory (which contains the PATH_DATA) + filename being passed to the locate function in the mod manager was being returned as PATH_DATA + PATH_DATA + filename. As a result, the file couldn't be loaded. This is my proposed fix.
