### PR TITLE
Powers: forced movement effect

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -246,6 +246,16 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 	Point target;
 	int stepfx;
 	stats.logic();
+	if (stats.forced_move_duration > 0) {
+		move();
+		// calc new cam position from player position
+		// cam is focused at player position
+		map->cam.x = stats.pos.x;
+		map->cam.y = stats.pos.y;
+		map->hero_tile.x = stats.pos.x / 32;
+		map->hero_tile.y = stats.pos.y / 32;
+		return;
+	}
 	if (stats.stun_duration > 0) return;
 	bool allowed_to_move;
 	bool allowed_to_use_power;
@@ -626,6 +636,12 @@ bool Avatar::takeHit(Hazard h) {
 			if (h.slow_duration > stats.slow_duration) stats.slow_duration = h.slow_duration;
 			if (h.bleed_duration > stats.bleed_duration) stats.bleed_duration = h.bleed_duration;
 			if (h.immobilize_duration > stats.immobilize_duration) stats.immobilize_duration = h.immobilize_duration;
+			if (h.forced_move_duration > stats.forced_move_duration) stats.forced_move_duration = h.forced_move_duration;
+			if (h.forced_move_speed != 0) {
+				float theta = powers->calcTheta(h.src_stats->pos.x, h.src_stats->pos.y, stats.pos.x, stats.pos.y);
+				stats.forced_speed.x = ceil((float)h.forced_move_speed * cos(theta));
+				stats.forced_speed.y = ceil((float)h.forced_move_speed * sin(theta));
+			}
 			if (h.hp_steal != 0) {
 				h.src_stats->hp += (int)ceil((float)dmg * (float)h.hp_steal / 100.0);
 				if (h.src_stats->hp > h.src_stats->maxhp) h.src_stats->hp = h.src_stats->maxhp;

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -103,6 +103,9 @@ void Enemy::newState(int state) {
 void Enemy::logic() {
 
 	stats.logic();
+	if (stats.forced_move_duration > 0) {
+		move(); return;
+	}
 	if (stats.stun_duration > 0) return;
 	// check for bleeding to death
 	if (stats.hp <= 0 && !(stats.cur_state == ENEMY_DEAD || stats.cur_state == ENEMY_CRITDEAD)) {
@@ -475,7 +478,7 @@ void Enemy::logic() {
 				if (activeAnimation->getCurFrame() == 1) {
 					sfx_die = true;
 				}
-            }
+			}
 
 			break;
 		
@@ -566,6 +569,12 @@ bool Enemy::takeHit(Hazard h) {
 			if (h.slow_duration > stats.slow_duration) stats.slow_duration = h.slow_duration;
 			if (h.bleed_duration > stats.bleed_duration) stats.bleed_duration = h.bleed_duration;
 			if (h.immobilize_duration > stats.immobilize_duration) stats.immobilize_duration = h.immobilize_duration;
+			if (h.forced_move_duration > stats.forced_move_duration) stats.forced_move_duration = h.forced_move_duration;
+			if (h.forced_move_speed != 0) {
+				float theta = powers->calcTheta(stats.hero_pos.x, stats.hero_pos.y, stats.pos.x, stats.pos.y);
+				stats.forced_speed.x = ceil((float)h.forced_move_speed * cos(theta));
+				stats.forced_speed.y = ceil((float)h.forced_move_speed * sin(theta));
+			}
 			if (h.hp_steal != 0) {
 				h.src_stats->hp += (int)ceil((float)dmg * (float)h.hp_steal / 100.0);
 				if (h.src_stats->hp > h.src_stats->maxhp) h.src_stats->hp = h.src_stats->maxhp;

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -36,6 +36,9 @@ Entity::Entity(MapIso* _map) : sprites(NULL), activeAnimation(NULL), map(_map) {
  * @return Returns false if wall collision, otherwise true.
  */
 bool Entity::move() {
+	if (stats.forced_move_duration > 0) {
+		return map->collider.move(stats.pos.x, stats.pos.y, stats.forced_speed.x, stats.forced_speed.y, 1);
+	}
 	if (stats.immobilize_duration > 0) return false;
 
 	int speed_diagonal = stats.dspeed;
@@ -230,7 +233,7 @@ Entity::~Entity () {
 	// delete all loaded animations
 	for (vector<Animation*>::const_iterator it = animations.begin(); it != animations.end(); it++)
 	{
-	    delete *it;
+		delete *it;
 	} 
 	animations.clear();
 }

--- a/src/Hazard.cpp
+++ b/src/Hazard.cpp
@@ -53,6 +53,8 @@ Hazard::Hazard() {
 	immobilize_duration=0;
 	slow_duration=0;
 	bleed_duration=0;
+	forced_move_speed=0;
+	forced_move_duration=0;
 	hp_steal=0;
 	mp_steal=0;
 	trait_armor_penetration = false;

--- a/src/Hazard.h
+++ b/src/Hazard.h
@@ -45,7 +45,7 @@ private:
 	MapCollision *collider;
 	// Keeps track of entities already hit
 	std::vector<Entity*> entitiesCollided;
-      
+	  
 public:
 	Hazard();
 
@@ -100,6 +100,8 @@ public:
 	int immobilize_duration;
 	int slow_duration;
 	int bleed_duration;
+	int forced_move_speed;
+	int forced_move_duration;
 	int hp_steal;
 	int mp_steal;
 	

--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -170,11 +170,11 @@ bool MapCollision::line_of_movement(int x1, int y1, int x2, int y2) {
 bool MapCollision::compute_path(Point start, Point end, vector<Point> &path, unsigned int limit) {
 	// path must be empty
 	if(!path.empty())
-	    path.clear();
+		path.clear();
 
 	// destination must be valid
 	if( !is_empty(end.x,end.y) )
-	    return false;
+		return false;
 
 	// convert start & end to MapCollision precision
 	start = map_to_collision(start);
@@ -242,8 +242,8 @@ bool MapCollision::compute_path(Point start, Point end, vector<Point> &path, uns
 		// store path from end to start
 		path.push_back(collision_to_map(end));
 		while( current.x != start.x || current.y != start.y ) {
-		    path.push_back(collision_to_map(current));
-		    current = find(close.begin(), close.end(), current)->getParent();
+			path.push_back(collision_to_map(current));
+			current = find(close.begin(), close.end(), current)->getParent();
 		}
 	}
 

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -251,6 +251,10 @@ void PowerManager::loadPowers(const std::string& filename) {
 				else if (infile.val == "shadow") powers[input_id].trait_elemental = ELEMENT_SHADOW;
 				else if (infile.val == "light") powers[input_id].trait_elemental = ELEMENT_LIGHT;
 			}
+			else if (infile.key == "forced_move") {
+				powers[input_id].forced_move_speed = atoi(infile.nextValue().c_str());
+				powers[input_id].forced_move_duration = atoi(infile.nextValue().c_str());
+			}
 			//steal effects
 			else if (infile.key == "hp_steal") {
 				powers[input_id].hp_steal = atoi(infile.val.c_str());
@@ -617,6 +621,9 @@ void PowerManager::initHazard(int power_index, StatBlock *src_stats, Point targe
 	haz->stun_duration += powers[power_index].stun_duration;
 	haz->slow_duration += powers[power_index].slow_duration;
 	haz->immobilize_duration += powers[power_index].immobilize_duration;
+	// forced move
+	haz->forced_move_speed += powers[power_index].forced_move_speed;
+	haz->forced_move_duration += powers[power_index].forced_move_duration;
 	// steal effects
 	haz->hp_steal += powers[power_index].hp_steal;
 	haz->mp_steal += powers[power_index].mp_steal;

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -130,6 +130,8 @@ struct Power {
 	int damage_multiplier; // % of base damage done by power (eg. 200 doubles damage and 50 halves it)
 	int starting_pos; // enum. (source, target, or melee)
 	bool multitarget;
+	int forced_move_speed;
+	int forced_move_duration;
 
 	//steal effects (in %, eg. hp_steal=50 turns 50% damage done into HP regain.)
 	int hp_steal;
@@ -219,6 +221,8 @@ struct Power {
 		base_damage = BASE_DAMAGE_NONE;
 		damage_multiplier = 100;
 		multitarget = false;
+		forced_move_speed = 0;
+		forced_move_duration = 0;
 
 		hp_steal = 0;
 		mp_steal = 0;
@@ -282,7 +286,6 @@ private:
 	std::string sfx_filenames[POWER_MAX_SFX];
 	int gfx_count;
 	int sfx_count;
-	float calcTheta(int x1, int y1, int x2, int y2);
 
 	int calcDirection(int origin_x, int origin_y, int target_x, int target_y);
 	void initHazard(int powernum, StatBlock *src_stats, Point target, Hazard *haz);
@@ -301,6 +304,7 @@ public:
 
 	void handleNewMap(MapCollision *_collider);
 	bool activate(int power_index, StatBlock *src_stats, Point target);
+	float calcTheta(int x1, int y1, int x2, int y2);
 
 	Power powers[POWER_COUNT];
 	std::queue<Hazard *> hazards; // output; read by HazardManager

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -70,6 +70,7 @@ StatBlock::StatBlock() {
 	haste_duration = 0;
 	hot_duration = 0;
 	hot_value = 0;
+	forced_move_duration = 0;
 	shield_hp = 0;
 	shield_frame = 0;
 	vengeance_stacks = 0;
@@ -288,8 +289,8 @@ void StatBlock::recalc() {
 	
 	int stat_sum = get_physical() + get_mental() + get_offense() + get_defense();
 
-    // TODO: These class names do. not get caught by xgettext, so figure out
-    // a way to translate them.
+	// TODO: These class names do. not get caught by xgettext, so figure out
+	// a way to translate them.
 
 	// determine class
 	// if all four stats are max, Grand Master
@@ -370,6 +371,8 @@ void StatBlock::logic() {
 		haste_duration--;
 	if (hot_duration > 0)
 		hot_duration--;
+	if (forced_move_duration > 0)
+		forced_move_duration--;
 	
 	// apply bleed
 	if (bleed_duration % FRAMES_PER_SEC == 1) {
@@ -401,6 +404,9 @@ void StatBlock::clearEffects() {
 	bleed_duration = 0;
 	stun_duration = 0;
 	shield_hp = 0;
+	slow_duration = 0;
+	haste_duration = 0;
+	forced_move_duration = 0;
 	vengeance_stacks = 0;
 }
 

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -146,6 +146,7 @@ public:
 	int haste_duration;
 	int hot_duration;
 	int hot_value;
+	int forced_move_duration;
 	
 	int shield_hp; // shield
 	int shield_frame;
@@ -156,6 +157,7 @@ public:
 	int speed;
 	int dspeed;
 	Point pos;
+	Point forced_speed;
 	int direction;
 	int hero_cooldown[1024]; //TODO: fix this to use POWER_COUNT... right now it can't #include "PowerManager.h"
 		


### PR DESCRIPTION
Powers can now include a forced movement effect. This will either propel the hit creature away from the caster or towards the caster, depending on if the speed is positive or negative.

Usage is:

```
forced_movement=(speed),(duration)
```

where speed is the same as missile speed and duration is in frames.

Try adding:

```
forced_movement=30,10
```

to a few powers to see it in action. I'd recommend quake, shoot and swing. Also, give

```
forced_movement=-30,10
```

a shot, though it's not quite as perfect as I'd like it. (They will be pulled towards the caster, but depending on the amount of movement might actually be pulled past the caster...)
