### PR TITLE
Additional power triggers for enemies

### DIFF
--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -54,6 +54,9 @@ const int ENEMY_BLOCK = 7;
 const int ENEMY_HIT = 8;
 const int ENEMY_DEAD = 9;
 const int ENEMY_CRITDEAD = 10;
+const int ENEMY_HALF_DEAD = 11;
+const int ENEMY_DEBUFF = 12;
+const int ENEMY_JOIN_COMBAT = 13;
 
 class Enemy : public Entity {
 protected:

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -196,6 +196,17 @@ void StatBlock::load(const string& filename) {
 			else if (infile.key == "cooldown_melee_ment") power_cooldown[MELEE_MENT] = num;
 			else if (infile.key == "cooldown_ranged_phys") power_cooldown[RANGED_PHYS] = num;
 			else if (infile.key == "cooldown_ranged_ment") power_cooldown[RANGED_MENT] = num;
+            else if (infile.key == "power_on_hit") power_index[ON_HIT] = num;
+			else if (infile.key == "power_on_death") power_index[ON_DEATH] = num;
+			else if (infile.key == "power_on_half_dead") power_index[ON_HALF_DEAD] = num;
+			else if (infile.key == "power_on_debuff") power_index[ON_DEBUFF] = num;
+			else if (infile.key == "power_on_join_combat") power_index[ON_JOIN_COMBAT] = num;
+            else if (infile.key == "chance_on_hit") power_chance[ON_HIT] = num;
+			else if (infile.key == "chance_on_death") power_chance[ON_DEATH] = num;
+			else if (infile.key == "chance_on_half_dead") power_chance[ON_HALF_DEAD] = num;
+			else if (infile.key == "chance_on_debuff") power_chance[ON_DEBUFF] = num;
+			else if (infile.key == "chance_on_join_combat") power_chance[ON_JOIN_COMBAT] = num;
+
 			
 			else if (infile.key == "melee_range") melee_range = num;
 			else if (infile.key == "threat_range") threat_range = num;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -32,12 +32,17 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 const int STAT_EFFECT_SHIELD = 0;
 const int STAT_EFFECT_VENGEANCE = 1;
 
-const int POWERSLOT_COUNT = 5;
+const int POWERSLOT_COUNT = 10;
 const int MELEE_PHYS = 0;
 const int MELEE_MENT = 1;
 const int RANGED_PHYS = 2;
 const int RANGED_MENT = 3;
 const int BEACON = 4;
+const int ON_HIT = 5;
+const int ON_DEATH = 6;
+const int ON_HALF_DEAD = 7;
+const int ON_DEBUFF = 8;
+const int ON_JOIN_COMBAT = 9;
 
 const int MAX_CHARACTER_LEVEL = 32;
 
@@ -179,6 +184,7 @@ public:
 	int dir_ticks;
 	int patrol_ticks;
 	bool in_combat;
+    bool join_combat;
 	int cooldown_ticks;
 	int cooldown; // min. # of frames between abilities
 	


### PR DESCRIPTION
Solves Issue #258.

The following keys can be used in enemy files to add powers to the various events.
- power_on_hit
- power_on_death
- power_on_half_dead
- power_on_debuff
- power_on_join_combat

Also, the following keys can be used to set the chance of casting the power when the event occurs.
- chance_on_hit
- chance_on_death
- chance_on_half_dead
- chance_on_debuff
- chance_on_join_combat
