### PR TITLE
Fix a warning about a parameter aliasing a member

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -27,7 +27,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "Animation.h"
 
-Animation::Animation(std::string _name, Point _render_size, Point _render_offset, int _position, int _frames, int _duration, std::string _type, int active_frame)
+Animation::Animation(std::string _name, Point _render_size, Point _render_offset, int _position, int _frames, int _duration, std::string _type, int /*_active_frame*/)
 	: name(_name), sprites(NULL),
 	  render_size(_render_size), render_offset(_render_offset),
 	  position(_position), frames(_frames), duration(_duration), type(_type),


### PR DESCRIPTION
I've renamed the parameter (it was missing the leading underscore), but also commented its name out, as it was not used in the function. (active_frame is initialized with 0 instead)
