### PR TITLE
Configurable sell prices on items

### DIFF
--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -192,6 +192,8 @@ void ItemManager::load(const string& filename) {
 				items[id].power_desc = msg->get(infile.val);
 			else if (infile.key == "price")
 				items[id].price = atoi(infile.val.c_str());
+			else if (infile.key == "price_sell")
+				items[id].price_sell = atoi(infile.val.c_str());
 			else if (infile.key == "max_quantity")
 				items[id].max_quantity = atoi(infile.val.c_str());
 			else if (infile.key == "rand_loot")
@@ -463,7 +465,11 @@ TooltipData ItemManager::getTooltip(int item, StatBlock *stats, bool vendor_view
 				tip.lines[tip.num_lines++] = msg->get("Buy Price: %d gold each", items[item].price);
 		}
 		else {
-			int price_per_unit = items[item].price/vendor_ratio;
+			int price_per_unit;
+			if(items[item].price_sell != 0)
+				price_per_unit = items[item].price_sell;
+			else
+				price_per_unit = items[item].price/vendor_ratio;
 			if (price_per_unit == 0) price_per_unit = 1;
 			if (items[item].max_quantity <= 1)
 				tip.lines[tip.num_lines++] = msg->get("Sell Price: %d gold", price_per_unit);

--- a/src/ItemManager.h
+++ b/src/ItemManager.h
@@ -96,6 +96,7 @@ struct Item {
 	int power_mod;        // alter powers when this item is equipped (e.g. shoot arrows from bows)
 	std::string power_desc;    // shows up in green text on the tooltip
 	int price;            // if price = 0 the item cannot be sold
+	int price_sell;       // if price_sell = 0, the sell price is price/vendor_ratio
 	int max_quantity;     // max count per stack
 	int rand_loot;        // max amount appearing in a loot stack
 	int rand_vendor;      // max amount appearing in a vendor stack
@@ -122,6 +123,7 @@ struct Item {
 		power_mod = -1;
 		power_desc = "";
 		price = 0;
+		price_sell = 0;
 		max_quantity = 1;
 		rand_loot = 1;
 		rand_vendor = 1;

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -478,7 +478,11 @@ bool MenuInventory::sell(ItemStack stack) {
 	// items that have no price cannot be sold
 	if (items->items[stack.item].price == 0) return false;
 	
-	int value_each = items->items[stack.item].price / items->vendor_ratio;
+	int value_each;
+	if(items->items[stack.item].price_sell != 0)
+		value_each = items->items[stack.item].price_sell;
+	else
+		value_each = items->items[stack.item].price / items->vendor_ratio;
 	if (value_each == 0) value_each = 1;
 	int value = value_each * stack.quantity;
 	gold += value;


### PR DESCRIPTION
This should help with issue #325. Use "price_sell" in the items.txt file to define the selling price for that type of item. If the value of price_sell = 0 (which is the default if it isn't defined), the sell price will fall back to the old method.
