### PR TITLE
Avoid cheating if permadeath is true

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -37,8 +37,6 @@ Avatar::Avatar(PowerManager *_powers, MapIso *_map) : Entity(_map), powers(_powe
 
 	init();
 
-	permadeath = false;
-
 	// default hero animation data
 	stats.cooldown = 4;
 
@@ -508,7 +506,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			if (activeAnimation->getCurFrame() == 1 && activeAnimation->getTimesPlayed() < 1) {
 				if (sound_die)
 					Mix_PlayChannel(-1, sound_die, 0);
-				if (permadeath) {
+				if (stats.permadeath) {
 					log_msg = msg->get("You are defeated. Game over! Press Enter to exit to Title.");
 				}
 				else {
@@ -524,7 +522,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			if (inpt->pressing[ACCEPT]) {
 				map->teleportation = true;
 				map->teleport_mapname = map->respawn_map;
-				if (permadeath) {
+				if (stats.permadeath) {
 					// set these positions so it doesn't flash before jumping to Title
 					map->teleport_destination.x = stats.pos.x;
 					map->teleport_destination.y = stats.pos.y;

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -79,8 +79,6 @@ public:
 	Avatar(PowerManager *_powers, MapIso *_map);
 	~Avatar();
 
-    bool permadeath;
-
 	void init();
 	void loadGraphics(const std::string& img_main, std::string img_armor, const std::string& img_off);
 	void loadSounds();

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -171,7 +171,7 @@ void GameStateNew::logic() {
 		play->pc->stats.head = head[current_option];
 		play->pc->stats.portrait = portrait[current_option];
 		play->pc->stats.name = input_name->getText();
-		play->pc->permadeath = button_permadeath->isChecked();
+		play->pc->stats.permadeath = button_permadeath->isChecked();
 		play->game_slot = game_slot;
 		play->resetGame();
 		requestedGameState = play;

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -207,7 +207,7 @@ void GameStatePlay::checkTeleport() {
 			map->respawn_point.y = pc->stats.pos.y;
 
 			// return to title (permadeath) OR auto-save
-			if (pc->permadeath && pc->stats.corpse) {
+			if (pc->stats.permadeath && pc->stats.corpse) {
 			    stringstream filename;
 			    filename << PATH_USER << "save" << game_slot << ".txt";
 			    if(remove(filename.str().c_str()) != 0)

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -153,7 +153,7 @@ void MenuManager::logic() {
 	}
 
 	// exit menu toggle
-	if ((inpt->pressing[CANCEL] && !inpt->lock[CANCEL] && !key_lock && !dragging)) {
+	if ((inpt->pressing[CANCEL] && !inpt->lock[CANCEL] && !key_lock && !dragging) && !(stats->corpse && stats->permadeath)) {
 		inpt->lock[CANCEL] = true;
 		key_lock = true;
 		if (menus_open) {

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -62,7 +62,7 @@ void GameStatePlay::saveGame() {
 		outfile << "name=" << pc->stats.name << "\n";
 
 		// permadeath
-		outfile << "permadeath=" << pc->permadeath << "\n";
+		outfile << "permadeath=" << pc->stats.permadeath << "\n";
 		
 		// hero visual option
 		outfile << "option=" << pc->stats.base << "," << pc->stats.head << "," << pc->stats.portrait << "\n";
@@ -128,7 +128,7 @@ void GameStatePlay::loadGame() {
 		while (infile.next()) {
 			if (infile.key == "name") pc->stats.name = infile.val;
 			else if (infile.key == "permadeath") {
-			    pc->permadeath = atoi(infile.val.c_str());
+			    pc->stats.permadeath = atoi(infile.val.c_str());
 			}
 			else if (infile.key == "option") {
 				pc->stats.base = infile.nextValue();

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -40,6 +40,7 @@ StatBlock::StatBlock() {
 	hero = false;
 	hero_pos.x = hero_pos.y = -1;
 	hero_alive = true;
+	permadeath = false;
 
 	flying = false;
 	incorporeal = false;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -86,6 +86,7 @@ public:
 	bool alive;
 	bool corpse; // creature is dead and done animating
 	bool hero; // else, enemy or other
+	bool permadeath;
 
 	bool flying;
 	bool incorporeal;


### PR DESCRIPTION
This adds leftover for issue #110. Moved permadeath property to StatBlock to be able to check if we need to disable ExitMenu if hero is dead.
