### PR TITLE
Transformation power improvements

### DIFF
--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -1069,6 +1069,7 @@ type=transform
 icon=20
 new_state=cast
 spawn_type=antlion_freezer
+requires_mp=5
 description=Transform into Antlion Freezer
 sfx=quake.ogg
 transform_duration=150

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -86,7 +86,6 @@ void Avatar::init() {
 	img_armor = "";
 	img_off = "";
 
-	transformed = false;
 	transform_triggered = false;
 	untransform_triggered = false;
 	setPowers = false;
@@ -682,7 +681,7 @@ bool Avatar::takeHit(Hazard h) {
 void Avatar::transform() {
 
 	transform_triggered = true;
-	transformed = true;
+	stats.transformed = true;
 	setPowers = true;
 
 	charmed_stats = new StatBlock();
@@ -715,13 +714,14 @@ void Avatar::transform() {
 	stats.speed = charmed_stats->speed;
 	stats.dspeed = charmed_stats->dspeed;
 	stats.flying = charmed_stats->flying;
+	stats.animations = charmed_stats->animations;
 
 	loadStepFX("NULL");
 }
 
 void Avatar::untransform() {
 
-	transformed = false;
+	stats.transformed = false;
 	transform_triggered = false;
 	untransform_triggered = true;
 	stats.transform_type = "";
@@ -731,7 +731,7 @@ void Avatar::untransform() {
 	stats.speed = hero_stats->speed;
 	stats.dspeed = hero_stats->dspeed;
 	stats.flying = hero_stats->flying;
-	// TODO append Experience
+	stats.animations = hero_stats->animations;
 }
 
 /**

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -75,7 +75,6 @@ private:
 	std::string img_armor;
 	std::string img_off;
 
-	bool transformed;
 	bool transform_triggered;
 
 public:

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -372,7 +372,7 @@ void GameStatePlay::checkNPCInteraction() {
 	}
 
 	// if close enough to the NPC, open the appropriate interaction screen
-	if (npc_click != -1 && interact_distance < max_interact_distance && pc->stats.alive) {
+	if (npc_click != -1 && interact_distance < max_interact_distance && pc->stats.alive && !pc->stats.transformed) {
 		inpt->lock[MAIN1] = true;
 
 		if (npcs->npcs[npc_id]->vendor) {

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -153,7 +153,7 @@ void MenuManager::logic() {
 	}
 
 	// exit menu toggle
-	if ((inpt->pressing[CANCEL] && !inpt->lock[CANCEL] && !key_lock && !dragging) && !(stats->corpse && stats->permadeath)) {
+	if ((inpt->pressing[CANCEL] && !inpt->lock[CANCEL] && !key_lock && !dragging) && !(stats->corpse && stats->permadeath) && !stats->transformed) {
 		inpt->lock[CANCEL] = true;
 		key_lock = true;
 		if (menus_open) {
@@ -165,7 +165,7 @@ void MenuManager::logic() {
 	}
 
 	// inventory menu toggle
-	if ((inpt->pressing[INVENTORY] && !key_lock && !dragging) || clicking_inventory) {
+	if (((inpt->pressing[INVENTORY] && !key_lock && !dragging) || clicking_inventory) && !stats->transformed) {
 		key_lock = true;
 		if (inv->visible) {
 			closeRight(true);
@@ -181,7 +181,7 @@ void MenuManager::logic() {
 	}
 
 	// powers menu toggle
-	if ((inpt->pressing[POWERS] && !key_lock && !dragging) || clicking_powers) {
+	if (((inpt->pressing[POWERS] && !key_lock && !dragging) || clicking_powers) && !stats->transformed) {
 		key_lock = true;
 		if (pow->visible) {
 			closeRight(true);
@@ -196,7 +196,7 @@ void MenuManager::logic() {
 	}
 
 	// character menu toggleggle
-	if ((inpt->pressing[CHARACTER] && !key_lock && !dragging) || clicking_character) {
+	if (((inpt->pressing[CHARACTER] && !key_lock && !dragging) || clicking_character) && !stats->transformed) {
 		key_lock = true;
 		if (chr->visible) {
 			closeLeft(true);
@@ -211,7 +211,7 @@ void MenuManager::logic() {
 	}
 
 	// log menu toggle
-	if ((inpt->pressing[LOG] && !key_lock && !dragging) || clicking_log) {
+	if (((inpt->pressing[LOG] && !key_lock && !dragging) || clicking_log) && !stats->transformed) {
 		key_lock = true;
 		if (log->visible) {
 			closeLeft(true);
@@ -366,7 +366,7 @@ void MenuManager::logic() {
 					act->remove(inpt->mouse);
 				}
 				// allow drag-to-rearrange action bar
-				else if (!isWithin(act->menuArea, inpt->mouse)) {
+				else if (!isWithin(act->menuArea, inpt->mouse) && !stats->transformed) {
 					drag_power = act->checkDrag(inpt->mouse);
 					if (drag_power > -1) {
 						dragging = true;

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -1022,6 +1022,10 @@ bool PowerManager::transform(int power_index, StatBlock *src_stats, Point target
 
 	src_stats->transform_type = powers[power_index].spawn_type;
 
+	// pay costs
+	if (src_stats->hero && powers[power_index].requires_mp > 0) src_stats->mp -= powers[power_index].requires_mp;
+	if (src_stats->hero && powers[power_index].requires_item != -1) used_item = powers[power_index].requires_item;
+
 	return true;
 }
 

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -42,6 +42,7 @@ StatBlock::StatBlock() {
 	hero_alive = true;
 	permadeath = false;
 	transform_type = "";
+	transformed = false;
 
 	flying = false;
 	incorporeal = false;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -87,6 +87,7 @@ public:
 	bool corpse; // creature is dead and done animating
 	bool hero; // else, enemy or other
 	bool permadeath;
+	bool transformed;
 
 	bool flying;
 	bool incorporeal;


### PR DESCRIPTION
Thsi request includes next changes:
1. Now transformation costs some MP
2. When hero is transformed, he can't
- open menus(inventory, log-quests, character, powers)
- save the game
- interract with NPCs
- edit ActionBar powers, introduced by transform

The one base feature, still not working is that transform powers still depend on requirements. IMHO they should be dropped as we pay MP for using transformation.
