### PR TITLE
Make threat_range resolution independent

### DIFF
--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -234,7 +234,7 @@ void StatBlock::load(const string& filename) {
 
 
 			else if (infile.key == "melee_range") melee_range = num;
-			else if (infile.key == "threat_range") threat_range = num;
+			else if (infile.key == "threat_range") threat_range = VIEW_W > VIEW_H ? ((float)num/VIEW_W_HALF)*VIEW_W : ((float)num/VIEW_H_HALF)*VIEW_H;
 
 			else if (infile.key == "attunement_fire") attunement_fire=num;
 			else if (infile.key == "attunement_ice") attunement_ice=num;


### PR DESCRIPTION
Right now, the threat_range for enemies is the same value no matter what resolution the game is running at. This allows players to use a ranged attack (such as Burn) to damage enemies from a large distance, preventing the enemy from entering combat (and thus chasing the player).

This commit should remedy that issue.
