### PR TITLE
Transformation features

### DIFF
--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -1070,6 +1070,16 @@ icon=20
 new_state=cast
 spawn_type=antlion_freezer
 requires_mp=5
-description=Transform into Antlion Freezer
+description=Transform into Antlion Freezer for 5 seconds
 sfx=quake.ogg
 transform_duration=150
+manual_untransform=true
+
+[power]
+id=136
+name=Disenchant
+type=transform
+icon=20
+new_state=cast
+description=Transform back to human
+sfx=quake.ogg

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -471,6 +471,7 @@ void GameStatePlay::logic() {
 			}
 			if (count == 12) count = 0;
 		}
+		if (pc->stats.manual_untransform) menu->act->hotkeys[count] = 136; //untransform power
 	}
 	// revert hero powers
 	if (pc->revertPowers) {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -312,6 +312,9 @@ void PowerManager::loadPowers(const std::string& filename) {
 			else if (infile.key == "transform_duration") {
 				powers[input_id].transform_duration = atoi(infile.val.c_str());
 			}
+			else if (infile.key == "manual_untransform") {
+				if (infile.val == "true") powers[input_id].manual_untransform = true;
+			}
 			else if (infile.key == "haste_duration") {
 				powers[input_id].haste_duration = atoi(infile.val.c_str());
 			}
@@ -741,7 +744,8 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 	}
 
 	// transform_duration causes hero to be transformed
-	if (src_stats->transform_duration < powers[power_index].transform_duration) {
+	if (src_stats->transform_duration < powers[power_index].transform_duration &&
+		src_stats->transform_duration !=-1) {
 		src_stats->transform_duration = powers[power_index].transform_duration;
 	}
 
@@ -1017,10 +1021,22 @@ bool PowerManager::transform(int power_index, StatBlock *src_stats, Point target
 	// apply any buffs
 	buff(power_index, src_stats, target);
 
+	src_stats->manual_untransform = powers[power_index].manual_untransform;
+
 	// If there's a sound effect, play it here
 	playSound(power_index, src_stats);
 
-	src_stats->transform_type = powers[power_index].spawn_type;
+	// power with id=136 is untransform power, its transform_type field is empty
+	if (power_index == 136) {
+		src_stats->transform_duration = 0;
+		src_stats->transform_type = "NULL"; // untransform() is called only if type !=""
+	}
+	else {
+		// permanent transformation
+		if (powers[power_index].transform_duration == 0) src_stats->transform_duration = -1;
+
+		src_stats->transform_type = powers[power_index].spawn_type;
+	}
 
 	// pay costs
 	if (src_stats->hero && powers[power_index].requires_mp > 0) src_stats->mp -= powers[power_index].requires_mp;

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -161,6 +161,7 @@ struct Power {
 	int immobilize_duration;
 	int immunity_duration;
 	int transform_duration;
+	bool manual_untransform; // true binds to the power another recurrence power
 	int haste_duration;
 	int hot_duration;
 	int hot_value;
@@ -250,6 +251,7 @@ struct Power {
 		immobilize_duration = 0;
 		immunity_duration = 0;
 		transform_duration = 0;
+		manual_untransform = false;
 		haste_duration = 0;
 		hot_duration = 0;
 		hot_value = 0;

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -82,6 +82,7 @@ StatBlock::StatBlock() {
 	immobilize_duration = 0;
 	immunity_duration = 0;
 	transform_duration = 0;
+	manual_untransform = false;
 	haste_duration = 0;
 	hot_duration = 0;
 	hot_value = 0;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -174,6 +174,7 @@ public:
 	int immobilize_duration;
 	int immunity_duration;
 	int transform_duration;
+	bool manual_untransform;
 	int haste_duration;
 	int hot_duration;
 	int hot_value;


### PR DESCRIPTION
This request adds:
- untransform power (id=136). Can be used independently. "manual_untransform" key tells if current power is binded with untransform power
- added permanent (in time) transform. Just avoid adding "transform_duration" or set it to 0
