### PR TITLE
Improve screen resolution combobox

### DIFF
--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -49,7 +49,7 @@ public:
 
 private:
 	int optiontab[78];
-	SDL_Rect** video_modes;
+	SDL_Rect* video_modes;
 
 	std::string * language_ISO;
 	std::string * language_full;


### PR DESCRIPTION
In response to issue #386.
I've made two changes to the resolution dropdown:
1. No resolutions below 640x480 are displayed
2. A few common resolutions (including Flare's recommended 720x480) are also listed.
