### PR TITLE
Remove keyboard layout ComboBox

### DIFF
--- a/mods/fantasycore/menus/config.txt
+++ b/mods/fantasycore/menus/config.txt
@@ -54,7 +54,6 @@ ctrl=65,670,185,670
 shift=65,700,185,700
 delete=65,730,185,730
 secondary_offset=145,0
-keyboard_layout=250,100
 
 [mods]
 activemods=435,90,400,120

--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -87,13 +87,10 @@ GameStateConfig::GameStateConfig ()
 	for (unsigned int i = 0; i < 50; i++) {
 		 settings_key[i] = new WidgetButton(mods->locate("images/menus/buttons/button_default.png"));
 	}
-	keyboard_layout = new WidgetComboBox(2, mods->locate("images/menus/buttons/combobox_default.png"));
-	keyboard_layout->set(0, "QWERTY");
-	keyboard_layout->set(1, "AZERTY");
 
-	input_scrollbox = new WidgetScrollBox(600, 230, 780);
+	input_scrollbox = new WidgetScrollBox(600, 280, 780);
 	input_scrollbox->pos.x = (VIEW_W - 640)/2 + 10;
-	input_scrollbox->pos.y = (VIEW_H - 480)/2 + 150;
+	input_scrollbox->pos.y = (VIEW_H - 480)/2 + 100;
 	input_scrollbox->refresh();
 
 	settings_btn[0] = new WidgetButton(mods->locate("images/menus/buttons/up.png"));
@@ -191,7 +188,6 @@ GameStateConfig::GameStateConfig ()
 			else if (infile.key == "activemods_deactivate") setting_num = 44;
 			else if (infile.key == "inactivemods_activate") setting_num = 45;
 			else if (infile.key == "secondary_offset") {offset_x = x1; offset_y = y1;}
-			else if (infile.key == "keyboard_layout") setting_num = 46;
 
 			if (setting_num != -1) {
 				if (setting_num > 12 && setting_num < 38) {
@@ -220,9 +216,6 @@ GameStateConfig::GameStateConfig ()
 				} else if (setting_num > 41 && setting_num < 46) {
 					settings_btn[setting_num-42]->pos.x = (VIEW_W - 640)/2 + x1;
 					settings_btn[setting_num-42]->pos.y = (VIEW_H - 480)/2 + y1;
-				} else if (setting_num == 46) {
-					keyboard_layout->pos.x = (VIEW_W - 640)/2 + x1;
-					keyboard_layout->pos.y = (VIEW_H - 480)/2 + y1;
 				}
 			}
 
@@ -374,9 +367,6 @@ GameStateConfig::GameStateConfig ()
 		 child_widget.push_back(settings_key[i]);
 		 optiontab[child_widget.size()-1] = 3;
 	}
-	keyboard_layout->refresh();
-	child_widget.push_back(keyboard_layout);
-	optiontab[child_widget.size()-1] = 3;
 
 	// Add ListBoxes
 	settings_lb[39]->set(msg->get("Active Mods"));
@@ -422,7 +412,6 @@ GameStateConfig::~GameStateConfig()
 	delete ok_button;
 	delete defaults_button;
 	delete cancel_button;
-	delete keyboard_layout;
 	delete input_scrollbox;
 	delete input_confirm;
 	delete defaults_confirm;
@@ -565,8 +554,6 @@ void GameStateConfig::logic ()
 			loadDefaults();
 			delete msg;
 			msg = new MessageEngine();
-			if (keyboard_layout->selected == 0) inpt->defaultQwertyKeyBindings();
-			if (keyboard_layout->selected == 1) inpt->defaultAzertyKeyBindings();
 			update();
 			setDefaultResolution();
 			defaults_confirm->visible = false;
@@ -667,26 +654,6 @@ void GameStateConfig::logic ()
 				if (SDL_NumJoysticks() > 0) settings_cmb[0]->refresh();
 			} else if (settings_cmb[0]->checkClick()) {
 				JOYSTICK_DEVICE = settings_cmb[0]->selected;
-			} else if (keyboard_layout->checkClick()) {
-				if (keyboard_layout->selected == 0) inpt->defaultQwertyKeyBindings();
-				if (keyboard_layout->selected == 1) inpt->defaultAzertyKeyBindings();
-				for (unsigned int i = 0; i < 25; i++) {
-					if (inpt->binding[i] < 8) {
-						settings_key[i]->label = mouse_button[inpt->binding[i]-1];
-					} else {
-						settings_key[i]->label = SDL_GetKeyName((SDLKey)inpt->binding[i]);
-					}
-					settings_key[i]->refresh();
-				}
-				for (unsigned int i = 25; i < 50; i++) {
-					if (inpt->binding[i] < 8) {
-						settings_key[i]->label = mouse_button[inpt->binding_alt[i-25]-1];
-					} else {
-						settings_key[i]->label = SDL_GetKeyName((SDLKey)inpt->binding_alt[i-25]);
-					}
-					settings_key[i]->refresh();
-				}
-
 			}
 
 			input_scrollbox->logic();

--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -51,7 +51,7 @@ public:
 	void    render  ();
 
 private:
-	int optiontab[113];
+	int optiontab[112];
 	SDL_Rect* video_modes;
 
 	std::string * language_ISO;
@@ -84,7 +84,6 @@ private:
 	WidgetComboBox      * settings_cmb[3];
 	WidgetListBox       * settings_lstb[2];
 	WidgetButton        * settings_btn[4];
-	WidgetComboBox      * keyboard_layout;
 	WidgetScrollBox     * input_scrollbox;
 	MenuConfirm         * input_confirm;
 	MenuConfirm         * defaults_confirm;

--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -96,36 +96,12 @@ void InputState::defaultQwertyKeyBindings ()
 }
 
 
-void InputState::defaultAzertyKeyBindings ()
-{
-    defaultQwertyKeyBindings();
-        //
-        // Just replace a few here and there
-        //
-	binding[UP] = SDLK_z;
-	binding[DOWN] = SDLK_s;
-	binding[LEFT] = SDLK_q;
-	binding[RIGHT] = SDLK_d;
-
-	binding[BAR_1] = binding_alt[BAR_1] = SDLK_AMPERSAND;
-	binding[BAR_2] = binding_alt[BAR_2] = SDLK_WORLD_73;
-	binding[BAR_3] = binding_alt[BAR_3] = SDLK_QUOTEDBL;
-	binding[BAR_4] = binding_alt[BAR_4] = SDLK_QUOTE;
-	binding[BAR_5] = binding_alt[BAR_5] = SDLK_LEFTPAREN;
-	binding[BAR_6] = binding_alt[BAR_6] = SDLK_MINUS;
-	binding[BAR_7] = binding_alt[BAR_7] = SDLK_WORLD_72;
-	binding[BAR_8] = binding_alt[BAR_8] = SDLK_UNDERSCORE;
-	binding[BAR_9] = binding_alt[BAR_9] = SDLK_WORLD_71;
-	binding[BAR_0] = binding_alt[BAR_0] = SDLK_WORLD_64;
-}
-
-
 /**
  * Key bindings are found in config/keybindings.txt
  */
 void InputState::loadKeyBindings() {
 
-	FileParser infile;	
+	FileParser infile;
 	int key1;
 	int key2;
 	int cursor;
@@ -577,7 +553,7 @@ void InputState::handle(bool dump_event) {
 		}
 	}
 
-		
+
 }
 
 InputState::~InputState() {

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -77,7 +77,6 @@ public:
 	~InputState();
 
 	void defaultQwertyKeyBindings();
-	void defaultAzertyKeyBindings();
 	void loadKeyBindings();
 	void saveKeyBindings();
 	void handle(bool dump_event);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,13 +72,6 @@ static void init(const vector<string>	& args) {
     // Load tileset options (must be after ModManager is initialized)
 	loadTilesetSettings();
 
-	// Check the command line if we should override the key binding
-	if (binary_search(args.begin(), args.end(), string("--qwerty"))) {
-		inpt->defaultQwertyKeyBindings();
-	} else if (binary_search(args.begin(), args.end(), string("--azerty"))) {
-		inpt->defaultAzertyKeyBindings();
-	}
-
 	// Add Window Titlebar Icon
 	SDL_WM_SetIcon(IMG_Load(mods->locate("images/logo/icon.png").c_str()),NULL);
 


### PR DESCRIPTION
Remove keyboard layout ComboBox. Also remove Azerty preset and commandline key, because now keybindings  can be easily configurated from GUI. For issue #447
