### PR TITLE
Make spawn and teleport powers target neighboring tiles

### DIFF
--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -296,6 +296,7 @@ floor=true
 starting_pos=source
 buff_teleport=true
 range=512
+target_neighbor=true
 
 [power]
 id=16
@@ -1055,6 +1056,7 @@ icon=20
 spawn_type=antlion
 new_state=cast
 starting_pos=source
+target_neighbor=true
 
 [power]
 id=134
@@ -1064,6 +1066,7 @@ icon=20
 spawn_type=antlion_hatchling
 new_state=cast
 starting_pos=source
+target_neighbor=true
 
 [power]
 id=135
@@ -1095,3 +1098,4 @@ icon=20
 spawn_type=zombie_rotting
 new_state=cast
 starting_pos=source
+target_neighbor = true

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -181,6 +181,7 @@ struct Power {
 
 	// spawn info
 	std::string spawn_type;
+	bool target_neighbor;
 
 	Power() {
 		type = -1;
@@ -270,6 +271,7 @@ struct Power {
 
 		allow_power_mod = false;
 		spawn_type = "";
+		target_neighbor = false;
 	}
 
 };
@@ -298,6 +300,7 @@ private:
 
 	int calcDirection(int origin_x, int origin_y, int target_x, int target_y);
 	Point limitRange(int range, Point src, Point target);
+	Point targetNeighbor(Point target);
 	void initHazard(int powernum, StatBlock *src_stats, Point target, Hazard *haz);
 	void buff(int power_index, StatBlock *src_stats, Point target);
 	void playSound(int power_index, StatBlock *src_stats);


### PR DESCRIPTION
For issue #478.
From the testing I've done, it works pretty well. The zombie spawner in the plains pops out zombies around the grave (they spawn on top of it if there's no more room). Antlion blinkers now teleport near the player, instead of directly on them.
