### PR TITLE
Use a temporary rect for blitting WidgetButton

### DIFF
--- a/src/WidgetButton.cpp
+++ b/src/WidgetButton.cpp
@@ -132,7 +132,10 @@ void WidgetButton::render(SDL_Surface *target) {
 	else
 		src.y = BUTTON_GFX_NORMAL * pos.h;
 	
-	SDL_BlitSurface(buttons, &src, target, &pos);
+	// create a temporary rect so we don't modify pos
+	SDL_Rect offset = pos;
+
+	SDL_BlitSurface(buttons, &src, target, &offset);
 
 	wlabel.render(target);
 }


### PR DESCRIPTION
For issue #385.
Funnily enough, I ran into this exact problem (SDL_BlitSurface changing the position rect) a few days ago when working on a small project of my own. But I didn't even think to correlate it with Flare's buttons having position issues.
