### PR TITLE
Fix maps always being rendered in Ortho mode

### DIFF
--- a/src/MapIso.cpp
+++ b/src/MapIso.cpp
@@ -637,7 +637,7 @@ void MapIso::logic() {
 
 
 void MapIso::render(Renderable r[], int rnum) {
-    if (TILESET_ORTHOGONAL)
+    if (TILESET_ORIENTATION == TILESET_ORTHOGONAL)
         renderOrtho(r, rnum);
     else
         renderIso(r, rnum);


### PR DESCRIPTION
Was wondering why I couldn't notice the performance changes to the isometric map renderer.
Also, maybe this has something to do with issue #494?
