### PR TITLE
Update stance when transforming

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -772,6 +772,7 @@ void Avatar::transform() {
 	stats.animations = charmed_stats->animations;
 	stats.animationSpeed = charmed_stats->animationSpeed;
 	loadAnimations("animations/" + charmed_stats->animations + ".txt");
+	stats.cur_state = AVATAR_STANCE;
 
 	// damage
 	if (charmed_stats->dmg_melee_min > stats.dmg_melee_min)
@@ -833,6 +834,7 @@ void Avatar::untransform() {
 	stats.animations = hero_stats->animations;
 	stats.animationSpeed = hero_stats->animationSpeed;
 	loadAnimations("animations/hero.txt");
+	stats.cur_state = AVATAR_STANCE;
 
 	stats.dmg_melee_min = hero_stats->dmg_melee_min;
 	stats.dmg_melee_max = hero_stats->dmg_melee_max;

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -1128,7 +1128,6 @@ bool PowerManager::transform(int power_index, StatBlock *src_stats, Point target
 	else {
 		// permanent transformation
 		if (powers[power_index].transform_duration == 0) src_stats->transform_duration = -1;
-		else src_stats->transform_duration = powers[power_index].transform_duration;
 
 		src_stats->transform_type = powers[power_index].spawn_type;
 	}


### PR DESCRIPTION
Stops PowerManager::buff from being called twice and prevents the cast animation from continuing after transformation.
