### PR TITLE
Make WidgetScrollBox transparent

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -390,10 +390,12 @@ GameStateConfig::GameStateConfig ()
 	for (unsigned int i = 13; i < 38; i++) {
 		 settings_lb[i]->set(binding_name[i-13]);
 		 settings_lb[i]->setJustify(JUSTIFY_RIGHT);
+		 settings_lb[i]->render_to_alpha = true;
 		 child_widget.push_back(settings_lb[i]);
 		 optiontab[child_widget.size()-1] = 4;
 	}
 	for (unsigned int i = 0; i < 50; i++) {
+		 settings_key[i]->render_to_alpha = true;
 		 child_widget.push_back(settings_key[i]);
 		 optiontab[child_widget.size()-1] = 4;
 	}
@@ -695,6 +697,7 @@ void GameStateConfig::logic ()
 			input_scrollbox->logic();
 			if (isWithin(input_scrollbox->pos,inpt->mouse)) {
 				for (unsigned int i = 0; i < 50; i++) {
+					if (settings_key[i]->pressed || settings_key[i]->hover) input_scrollbox->update = true;
 					Point mouse = input_scrollbox->input_assist(inpt->mouse);
 					if (settings_key[i]->checkClick(mouse.x,mouse.y)) {
 						std::string confirm_msg;
@@ -751,10 +754,10 @@ void GameStateConfig::render ()
 
 	if (active_tab == 4) {
 		for (unsigned int i = 13; i < 38; i++) {
-			settings_lb[i]->render(input_scrollbox->contents);
+			if (input_scrollbox->update) settings_lb[i]->render(input_scrollbox->contents);
 		}
 		for (unsigned int i = 0; i < 50; i++) {
-			settings_key[i]->render(input_scrollbox->contents);
+			if (input_scrollbox->update) settings_key[i]->render(input_scrollbox->contents);
 		}
 		input_scrollbox->render();
 	}

--- a/src/Widget.h
+++ b/src/Widget.h
@@ -10,6 +10,7 @@ public:
     Widget() {};
 	virtual ~Widget() {};
 	virtual void render(SDL_Surface *target = NULL) = 0;
+	bool render_to_alpha;
 private:
 };
 

--- a/src/WidgetButton.cpp
+++ b/src/WidgetButton.cpp
@@ -21,6 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "WidgetButton.h"
 #include "SharedResources.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -34,6 +35,7 @@ WidgetButton::WidgetButton(const std::string& _fileName)
 	enabled = true;
 	pressed = false;
 	hover = false;
+	render_to_alpha = false;
 	
 	loadArt();
 
@@ -135,7 +137,10 @@ void WidgetButton::render(SDL_Surface *target) {
 	// create a temporary rect so we don't modify pos
 	SDL_Rect offset = pos;
 
-	SDL_BlitSurface(buttons, &src, target, &offset);
+	if (render_to_alpha)
+		SDL_gfxBlitRGBA(buttons, &src, target, &offset);
+	else
+		SDL_BlitSurface(buttons, &src, target, &offset);
 
 	wlabel.render(target);
 }

--- a/src/WidgetButton.h
+++ b/src/WidgetButton.h
@@ -44,7 +44,6 @@ private:
 
 	SDL_Surface *buttons;
 	Mix_Chunk *click;
-	bool hover;
 	
 	WidgetLabel wlabel;
 	
@@ -62,6 +61,7 @@ public:
 	SDL_Rect pos;
 	bool enabled;
 	bool pressed;
+	bool hover;
 };
 
 #endif

--- a/src/WidgetCheckBox.cpp
+++ b/src/WidgetCheckBox.cpp
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "Widget.h"
 #include "WidgetCheckBox.h"
 #include "SharedResources.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -49,6 +50,8 @@ WidgetCheckBox::WidgetCheckBox (const string  & fname)
 
 	pos.w = cb->w;
 	pos.h = cb->h / 2;
+
+	render_to_alpha = false;
 }
 
 WidgetCheckBox::~WidgetCheckBox ()
@@ -119,6 +122,9 @@ void WidgetCheckBox::render (SDL_Surface *target)
 	src.h = pos.h;
 	src.w = pos.w;
 
-	SDL_BlitSurface(cb, &src, target, &pos);
+	if (render_to_alpha)
+		SDL_gfxBlitRGBA(cb, &src, target, &pos);
+	else
+		SDL_BlitSurface(cb, &src, target, &pos);
 }
 

--- a/src/WidgetComboBox.cpp
+++ b/src/WidgetComboBox.cpp
@@ -22,6 +22,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "WidgetComboBox.h"
 #include "SharedResources.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -47,6 +48,7 @@ WidgetComboBox::WidgetComboBox(int amount, const std::string& _fileName)
 	pos.w = (comboboxs->w / 2);
 	pos.h = (comboboxs->h / 4); //height of one ComboBox
 
+	render_to_alpha = false;
 }
 
 void WidgetComboBox::loadArt() {
@@ -157,7 +159,10 @@ void WidgetComboBox::render(SDL_Surface *target) {
 	else
 		src.y = COMBOBOX_GFX_NORMAL * pos.h;
 
-	SDL_BlitSurface(comboboxs, &src, target, &pos);
+	if (render_to_alpha)
+		SDL_gfxBlitRGBA(comboboxs, &src, target, &pos);
+	else
+		SDL_BlitSurface(comboboxs, &src, target, &pos);
 
 	wlabel.render(target);
 
@@ -177,7 +182,10 @@ void WidgetComboBox::render(SDL_Surface *target) {
 				src.y = 0;
 
 			refresh();
-			SDL_BlitSurface(comboboxs, &src, target, &rows[i]);
+			if (render_to_alpha)
+				SDL_gfxBlitRGBA(comboboxs, &src, target, &rows[i]);
+			else
+				SDL_BlitSurface(comboboxs, &src, target, &rows[i]);
 			vlabels[i].render(target);
 		}
 	}

--- a/src/WidgetInput.cpp
+++ b/src/WidgetInput.cpp
@@ -18,6 +18,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "WidgetInput.h"
 #include "SharedResources.h"
 #include "Settings.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -38,6 +39,7 @@ WidgetInput::WidgetInput() {
 	
 	cursor_frame = 0;
 
+	render_to_alpha = false;
 }
 
 void WidgetInput::loadGraphics(const string& filename) {
@@ -129,7 +131,10 @@ void WidgetInput::render(SDL_Surface *target) {
 	else
 		src.y = pos.h;
 
-	SDL_BlitSurface(background, &src, target, &pos);
+	if (render_to_alpha)
+		SDL_gfxBlitRGBA(background, &src, target, &pos);
+	else
+		SDL_BlitSurface(background, &src, target, &pos);
 
 	if (!inFocus) {
 		font->render(text, font_pos.x, font_pos.y, JUSTIFY_LEFT, target, FONT_WHITE);

--- a/src/WidgetLabel.cpp
+++ b/src/WidgetLabel.cpp
@@ -23,6 +23,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "WidgetLabel.h"
 #include "SharedResources.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -37,6 +38,8 @@ WidgetLabel::WidgetLabel() {
 	
 	bounds.x = bounds.y = 0;
 	bounds.w = bounds.h = 0;
+
+	render_to_alpha = false;
 	
 }
 
@@ -55,7 +58,10 @@ void WidgetLabel::render(SDL_Surface *target) {
 	dest.h = bounds.h;
 
 	if (text_buffer != NULL) {
-		SDL_BlitSurface(text_buffer, NULL, target, &dest);
+		if (render_to_alpha)
+			SDL_gfxBlitRGBA(text_buffer, NULL, target, &dest);
+		else
+			SDL_BlitSurface(text_buffer, NULL, target, &dest);
 	}
 }
 

--- a/src/WidgetListBox.cpp
+++ b/src/WidgetListBox.cpp
@@ -22,6 +22,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "WidgetListBox.h"
 #include "SharedResources.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -57,6 +58,8 @@ WidgetListBox::WidgetListBox(int amount, int height, const std::string& _fileNam
 	pos.h = (listboxs->h / 3); //height of one item
 
 	scrollbar = new WidgetScrollBar(mods->locate("images/menus/buttons/scrollbar_default.png"));
+
+	render_to_alpha = false;
 }
 
 void WidgetListBox::loadArt() {
@@ -320,7 +323,10 @@ void WidgetListBox::render(SDL_Surface *target) {
 		else
 			src.y = pos.h;
 
-		SDL_BlitSurface(listboxs, &src, target, &rows[i]);
+		if (render_to_alpha)
+			SDL_gfxBlitRGBA(listboxs, &src, target, &rows[i]);
+		else
+			SDL_BlitSurface(listboxs, &src, target, &rows[i]);
 		if (i<list_amount) {
 			vlabels[i].render(target);
 		}

--- a/src/WidgetScrollBar.cpp
+++ b/src/WidgetScrollBar.cpp
@@ -22,6 +22,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "WidgetScrollBar.h"
 #include "SharedResources.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -35,6 +36,8 @@ WidgetScrollBar::WidgetScrollBar(const std::string& _fileName)
 
 	pos_up.w = pos_down.w  = pos_knob.w = scrollbars->w;
 	pos_up.h = pos_down.h = pos_knob.h = (scrollbars->h / 5); //height of one button
+
+	render_to_alpha = false;
 }
 
 void WidgetScrollBar::loadArt() {
@@ -166,9 +169,15 @@ void WidgetScrollBar::render(SDL_Surface *target) {
 	else
 		src_down.y = pos_down.h*2;
 
-	SDL_BlitSurface(scrollbars, &src_up, target, &pos_up);
-	SDL_BlitSurface(scrollbars, &src_down, target, &pos_down);
-	SDL_BlitSurface(scrollbars, &src_knob, target, &pos_knob);
+	if (render_to_alpha) {
+		SDL_gfxBlitRGBA(scrollbars, &src_up, target, &pos_up);
+		SDL_gfxBlitRGBA(scrollbars, &src_down, target, &pos_down);
+		SDL_gfxBlitRGBA(scrollbars, &src_knob, target, &pos_knob);
+	} else {
+		SDL_BlitSurface(scrollbars, &src_up, target, &pos_up);
+		SDL_BlitSurface(scrollbars, &src_down, target, &pos_down);
+		SDL_BlitSurface(scrollbars, &src_knob, target, &pos_knob);
+	}
 }
 
 /**

--- a/src/WidgetScrollBox.cpp
+++ b/src/WidgetScrollBox.cpp
@@ -21,6 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
  */
 
 #include "WidgetScrollBox.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -30,9 +31,9 @@ WidgetScrollBox::WidgetScrollBox(int width, int height, int full_height) {
 	pos.h = height;
     cursor = 0;
     contents = createSurface(width,full_height);
-	SDL_FillRect(contents,NULL,0x1A1A1A);
-	SDL_SetAlpha(contents, 0, 0);
 	scrollbar = new WidgetScrollBar(mods->locate("images/menus/buttons/scrollbar_default.png"));
+	update = true;
+    render_to_alpha = false;
 }
 
 WidgetScrollBox::~WidgetScrollBox() {
@@ -94,7 +95,11 @@ void WidgetScrollBox::render(SDL_Surface *target) {
 	src.w = contents->w;
 	src.h = pos.h;
 
-	SDL_BlitSurface(contents, &src, target, &pos);
-    scrollbar->render(target);
+    if (render_to_alpha)
+        SDL_gfxBlitRGBA(contents, &src, target, &pos);
+    else
+        SDL_BlitSurface(contents, &src, target, &pos);
+	scrollbar->render(target);
+	update = false;
 }
 

--- a/src/WidgetScrollBox.h
+++ b/src/WidgetScrollBox.h
@@ -42,6 +42,7 @@ public:
 
 	SDL_Rect pos;
 	SDL_Surface * contents;
+	bool update;
 
 private:
 	void scroll(int amount);

--- a/src/WidgetSlider.cpp
+++ b/src/WidgetSlider.cpp
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "WidgetSlider.h"
 #include "SharedResources.h"
 #include "UtilsDebug.h"
+#include "SDL_gfxBlitFunc.h"
 
 using namespace std;
 
@@ -51,6 +52,8 @@ WidgetSlider::WidgetSlider (const string  & fname)
 
 	pos_knob.w = sl->w / 8;
 	pos_knob.h = sl->h / 2;
+
+	render_to_alpha = false;
 }
 
 WidgetSlider::~WidgetSlider ()
@@ -153,7 +156,12 @@ void WidgetSlider::render (SDL_Surface *target)
 	knob.h = pos_knob.h;
 	knob.w = pos_knob.w;
 
-	SDL_BlitSurface(sl, &base, target, &pos);
-	SDL_BlitSurface(sl, &knob, target, &pos_knob);
+	if (render_to_alpha) {
+		SDL_gfxBlitRGBA(sl, &base, target, &pos);
+		SDL_gfxBlitRGBA(sl, &knob, target, &pos_knob);
+	} else {
+		SDL_BlitSurface(sl, &base, target, &pos);
+		SDL_BlitSurface(sl, &knob, target, &pos_knob);
+	}
 }
 


### PR DESCRIPTION
Since the surface that we want to blit to is now transparent, we need to use SDL_gfxBlitRGBA to apply those things. I've updated the widgets so that we can set render_to_alpha = true if we want to blit said widget onto a WidgetScrollBox.

I also added an update variable to WidgetScrollBox, to prevent updating the contents every frame (which can be really slow with SDL_gfxBlitRGBA).
