### PR TITLE
Move stats definitions to config file

### DIFF
--- a/mods/fantasycore/engine/stats.txt
+++ b/mods/fantasycore/engine/stats.txt
@@ -1,0 +1,23 @@
+# Avatar Attributes Definitions
+# Values should be integer
+
+hp_base=50
+hp_per_level=2
+hp_per_physical=8
+hp_regen_base=10
+hp_regen_per_level=1
+hp_regen_per_physical=4
+mp_base=50
+mp_per_level=2
+mp_per_mental=8
+mp_regen_base=10
+mp_regen_per_level=1
+mp_regen_per_mental=4
+accuracy_base=75
+accuracy_per_level=5
+accuracy_per_offense=5
+avoidance_base=25
+avoidance_per_level=1
+avoidance_per_defense=5
+crit_base=5
+crit_per_level=1

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -346,6 +346,59 @@ void StatBlock::recalc() {
 	int crit_base = 5;
 	int crit_per_level = 1;
 
+	// Redefine numbers from config file if present
+	int value;
+	FileParser infile;
+	if (infile.open(mods->locate("engine/stats.txt"))) {
+	  while (infile.next()) {
+		infile.val = infile.val + ',';
+		value = eatFirstInt(infile.val, ',');
+
+		if (infile.key == "hp_base") {
+			hp_base = value;
+		} else if (infile.key == "hp_per_level") {
+			hp_per_level = value;
+		} else if (infile.key == "hp_per_physical") {
+			hp_per_physical = value;
+		} else if (infile.key == "hp_regen_base") {
+			hp_regen_base = value;
+		} else if (infile.key == "hp_regen_per_level") {
+			hp_regen_per_level = value;
+		} else if (infile.key == "hp_regen_per_physical") {
+			hp_regen_per_physical = value;
+		} else if (infile.key == "mp_base") {
+			mp_base = value;
+		} else if (infile.key == "mp_per_level") {
+			mp_per_level = value;
+		} else if (infile.key == "mp_per_mental") {
+			mp_per_mental = value;
+		} else if (infile.key == "mp_regen_base") {
+			mp_regen_base = value;
+		} else if (infile.key == "mp_regen_per_level") {
+			mp_regen_per_level = value;
+		} else if (infile.key == "mp_regen_per_mental") {
+			mp_regen_per_mental = value;
+		} else if (infile.key == "accuracy_base") {
+			accuracy_base = value;
+		} else if (infile.key == "accuracy_per_level") {
+			accuracy_per_level = value;
+		} else if (infile.key == "accuracy_per_offense") {
+			accuracy_per_offense = value;
+		} else if (infile.key == "avoidance_base") {
+			avoidance_base = value;
+		} else if (infile.key == "avoidance_per_level") {
+			avoidance_per_level = value;
+		} else if (infile.key == "avoidance_per_defense") {
+			avoidance_per_defense = value;
+		} else if (infile.key == "crit_base") {
+			crit_base = value;
+		} else if (infile.key == "crit_per_level") {
+			crit_per_level = value;
+		}
+	  }
+	} else fprintf(stderr, "Unable to open stats.txt!\n");
+	infile.close();
+
 	int lev0 = level -1;
 	int phys0 = get_physical() -1;
 	int ment0 = get_mental() -1;


### PR DESCRIPTION
I think we still need to leave assigns inside source code. It doesn't hurt and avoids unexpected situations when stats.txt is missing.
