### PR TITLE
Fixed segfault from lack of bounds checking.

### DIFF
--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -146,7 +146,7 @@ void LootManager::calcTables() {
 
 	int level;
 
-	for (int i=0; i<1024; i++) {
+	for (unsigned int i=0; i<items->items.size(); i++) {
 		level = items->items[i].level;
 		if (level > 0) {
 			if (items->items[i].quality == ITEM_QUALITY_LOW) {


### PR DESCRIPTION
When there's a small items.txt file, program segfaults. It was an old bounds check.
