### PR TITLE
Reenable requirements check for power menu

### DIFF
--- a/mods/fantasycore/menus/powers.txt
+++ b/mods/fantasycore/menus/powers.txt
@@ -1,4 +1,9 @@
 # Settings for the PowersMenu display
+# Use next requirements for powers to unlock
+# Physical + Offense grants melee and ranged attacks
+# Physical + Defense grants melee protection
+# Mental + Offense grants elemental spell attacks
+# Mental + Defense grants healing and magical protection
 
 closebutton_pos=294,2
 unspent_points_pos=160,396
@@ -6,80 +11,104 @@ unspent_points_pos=160,396
 [power]
 id=0
 position=48,80
+requires_physoff=1
 
 [power]
 id=1
 position=112,80
+requires_physdef=1
 
 [power]
 id=2
 position=176,80
+requires_mentoff=1
 
 [power]
 id=3
 position=240,80
+requires_mentdef=1
 
 [power]
 id=4
 position=48,144
+requires_physoff=3
 
 [power]
 id=5
 position=112,144
+requires_physdef=3
 
 [power]
 id=6
 position=176,144
+requires_mentoff=3
 
 [power]
 id=7
 position=240,144
+requires_mentdef=3
 
 [power]
 id=8
 position=48,208
+requires_physoff=5
 
 [power]
 id=9
 position=112,208
+requires_physdef=5
 
 [power]
 id=10
 position=176,208
+requires_mentoff=5
 
 [power]
 id=11
 position=240,208
+requires_mentdef=5
 
 [power]
 id=12
 position=48,272
+requires_physoff=7
 
 [power]
 id=13
 position=112,272
+requires_physdef=7
 
 [power]
 id=14
 position=176,272
+requires_mentoff=7
 
 [power]
 id=15
 position=240,272
+requires_mentdef=7
 
 [power]
 id=16
 position=48,336
+requires_physoff=9
+requires_point=true
 
 [power]
 id=17
 position=112,336
+requires_physdef=9
+requires_point=true
 
 [power]
 id=18
 position=176,336
+requires_mentoff=9
+requires_point=true
 
 [power]
 id=19
 position=240,336
+requires_mentdef=9
+requires_point=true
 

--- a/src/MenuPowers.h
+++ b/src/MenuPowers.h
@@ -34,16 +34,21 @@ class PowerManager;
 class StatBlock;
 class TooltipData;
 
-struct Power_UI {
+struct Power_Menu_Cell {
 	int id;
 	Point pos;
+	int requires_physoff;
+	int requires_physdef;
+	int requires_mentoff;
+	int requires_mentdef;
+	bool requires_point;
 };
 
 class MenuPowers : public Menu {
 private:
 	StatBlock *stats;
 	PowerManager *powers;
-	Power_UI power_ui[20];
+	Power_Menu_Cell power_cell[20];
 
 	SDL_Surface *background;
 	SDL_Surface *icons;

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -336,6 +336,7 @@ public:
 	 * static mechanism of expecting disciplines to be index zero to 19.
 	 */
 	static unsigned getRequiredStatValue(unsigned powerid, unsigned stat) {
+		// TODO This is hadrcoded
 		return (powerid > 19 || stat != powerid % 4) ? 0 : (powerid / 4) * 2 + 1;
 	}
 };


### PR DESCRIPTION
Requirements are the same now as before rewrite, but now located in config file. Spending point to unlock was broken.

Renamed power_ui[i] into power_cell[i] to make more readable.
