### PR TITLE
MenuMiniMap: Move creation of SDL_Surface into utils.

### DIFF
--- a/src/MenuHUDLog.cpp
+++ b/src/MenuHUDLog.cpp
@@ -103,7 +103,7 @@ void MenuHUDLog::add(const string& s) {
 
 	// render the log entry and store it in a buffer
 	Point size = font->calc_size(s, window_area.w);
-	msg_buffer[log_count] = createSurface(size.x, size.y);
+	msg_buffer[log_count] = createAlphaSurface(size.x, size.y);
 	font->renderShadowed(s, 0, 0, JUSTIFY_LEFT, msg_buffer[log_count], window_area.w, FONT_WHITE);
 
 	log_count++;

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -164,7 +164,7 @@ void MenuLog::add(const string& s, int log_type) {
 	// Render the log entry and store it in a buffer.
 	int widthLimit = tabControl->getContentArea().w;
 	Point size = font->calc_size(s, widthLimit);
-	msg_buffer[log_type][log_count[log_type]] = createSurface(size.x, size.y);
+	msg_buffer[log_type][log_count[log_type]] = createAlphaSurface(size.x, size.y);
 	font->renderShadowed(s, 0, 0, JUSTIFY_LEFT, msg_buffer[log_type][log_count[log_type]], widthLimit, FONT_WHITE);
 
 	log_count[log_type]++;

--- a/src/MenuMiniMap.cpp
+++ b/src/MenuMiniMap.cpp
@@ -38,29 +38,7 @@ MenuMiniMap::MenuMiniMap() {
 
 void MenuMiniMap::createMapSurface() {
 
-	Uint32 rmask, gmask, bmask, amask;
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	rmask = 0xff000000;
-	gmask = 0x00ff0000;
-	bmask = 0x0000ff00;
-	amask = 0x000000ff;
-#else
-	rmask = 0x000000ff;
-	gmask = 0x0000ff00;
-	bmask = 0x00ff0000;
-	amask = 0xff000000;
-#endif
-
-	if (HWSURFACE)
-		map_surface = SDL_CreateRGBSurface(SDL_HWSURFACE, 128, 128, 32, rmask, gmask, bmask, amask);
-	else
-		map_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, 128, 128, 32, rmask, gmask, bmask, amask);
-
-	SDL_SetColorKey(map_surface, SDL_SRCCOLORKEY, SDL_MapRGB(map_surface->format,255,0,255));
-
-	SDL_Surface *cleanup = map_surface;
-	map_surface = SDL_DisplayFormat(map_surface);
-	SDL_FreeSurface(cleanup);
+	map_surface = createSurface(128, 128);
 
 	color_wall = SDL_MapRGB(map_surface->format, 128,128,128);
 	color_obst = SDL_MapRGB(map_surface->format, 64,64,64);

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -165,7 +165,7 @@ void MenuTalker::createBuffer() {
 
 	// render text to back buffer
 	SDL_FreeSurface(msg_buffer);
-	msg_buffer = createSurface(576,96);
+	msg_buffer = createAlphaSurface(576,96);
 	font->render(line, 16, 16, JUSTIFY_LEFT, msg_buffer, 544, FONT_WHITE);
 
 }

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -75,6 +75,22 @@ bool isWithin(SDL_Rect r, Point target);
 void drawPixel(SDL_Surface *screen, int x, int y, Uint32 color);
 void drawLine(SDL_Surface *screen, int x0, int y0, int x1, int y1, Uint32 color);
 void drawLine(SDL_Surface *screen, Point pos0, Point pos1, Uint32 color);
-SDL_Surface* createSurface(int width, int height);
 
+/**
+ * Creates a SDL_Surface.
+ * The SDL_HWSURFACE or SDL_SWSURFACE flag is set according
+ * to settings. The result is a surface which has the same format as the
+ * screen surface.
+ * Additionally the alpha flag is set, so transparent blits are possible.
+ */
+SDL_Surface* createAlphaSurface(int width, int height);
+
+/**
+ * Creates a SDL_Surface.
+ * The SDL_HWSURFACE or SDL_SWSURFACE flag is set according
+ * to settings. The result is a surface which has the same format as the
+ * screen surface.
+ * The bright pink (rgb 0xff00ff) is set as transparent color.
+ */
+SDL_Surface* createSurface(int width, int height);
 #endif

--- a/src/WidgetLabel.cpp
+++ b/src/WidgetLabel.cpp
@@ -220,7 +220,7 @@ void WidgetLabel::set(const string& _text) {
 void WidgetLabel::refresh() {
 
 	SDL_FreeSurface(text_buffer);
-	text_buffer = createSurface(bounds.w, bounds.h);
+	text_buffer = createAlphaSurface(bounds.w, bounds.h);
 	font->renderShadowed(text, 0, 0, JUSTIFY_LEFT, text_buffer, color);
 	
 }

--- a/src/WidgetScrollBox.cpp
+++ b/src/WidgetScrollBox.cpp
@@ -85,7 +85,7 @@ void WidgetScrollBox::resize(int h) {
 	if (contents != NULL) SDL_FreeSurface(contents);
 
 	if (pos.h > h) h = pos.h;
-	contents = createSurface(pos.w,h);
+	contents = createAlphaSurface(pos.w,h);
 	SDL_FillRect(contents,NULL,0x1A1A1A);
 	SDL_SetAlpha(contents, 0, 0);
 

--- a/src/WidgetTooltip.cpp
+++ b/src/WidgetTooltip.cpp
@@ -121,8 +121,8 @@ void WidgetTooltip::createBuffer(TooltipData &tip) {
 	Point size = font->calc_size(fulltext, width);
 	
 	// WARNING: dynamic memory allocation. Be careful of memory leaks.
-	tip.tip_buffer = createSurface(size.x + margin+margin, size.y + margin+margin);
-	
+	tip.tip_buffer = createAlphaSurface(size.x + margin+margin, size.y + margin+margin);
+
 	// Currently tooltips are always opaque
 	SDL_SetAlpha(tip.tip_buffer, 0, 0);
 	


### PR DESCRIPTION
First step as discussed in #604

There already existed a createSurface function, but that did not work with the buffer of the minimap as the transparency was incorrect. I tried to reformat the created surface in the original createSurface method, but that was error prone, so I renamed the existing createSurface to createAlphaSurface and added another createSurface function.
