### PR TITLE
Remove memleaks.

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -104,6 +104,12 @@ void Avatar::init() {
 	for (int i=0; i<4; i++) {
 		sound_steps[i] = NULL;
 	}
+
+	sound_melee = NULL;
+	sound_hit = NULL;
+	sound_die = NULL;
+	sound_block = NULL;
+	level_up = NULL;
 }
 
 void Avatar::loadGraphics(const string& _img_main, string _img_armor, const string& _img_off) {
@@ -172,7 +178,13 @@ void Avatar::loadGraphics(const string& _img_main, string _img_armor, const stri
 }
 
 void Avatar::loadSounds() {
-	if (audio == true) {
+	if (audio) {
+		Mix_FreeChunk(sound_melee);
+		Mix_FreeChunk(sound_hit);
+		Mix_FreeChunk(sound_die);
+		Mix_FreeChunk(sound_block);
+		Mix_FreeChunk(level_up);
+
 		sound_melee = Mix_LoadWAV(mods->locate("soundfx/melee_attack.ogg").c_str());
 		sound_hit = Mix_LoadWAV(mods->locate("soundfx/" + stats.base + "_hit.ogg").c_str());
 		sound_die = Mix_LoadWAV(mods->locate("soundfx/" + stats.base + "_die.ogg").c_str());
@@ -182,12 +194,6 @@ void Avatar::loadSounds() {
 		if (!sound_melee || !sound_hit || !sound_die || !level_up) {
 			printf("Mix_LoadWAV: %s\n", Mix_GetError());
 		}
-	} else {
-		sound_melee = NULL;
-		sound_hit = NULL;
-		sound_die = NULL;
-		sound_block = NULL;
-		level_up = NULL;
 	}
 }
 
@@ -891,24 +897,15 @@ Avatar::~Avatar() {
 	SDL_FreeSurface(sprites);
 	if (transformed_sprites) SDL_FreeSurface(transformed_sprites);
 
-	if (sound_melee)
-		Mix_FreeChunk(sound_melee);
-	if (sound_hit)
-		Mix_FreeChunk(sound_hit);
-	if (sound_die)
-		Mix_FreeChunk(sound_die);
-	if (sound_block)
-		Mix_FreeChunk(sound_block);
-	if (sound_steps[0])
-		Mix_FreeChunk(sound_steps[0]);
-	if (sound_steps[1])
-		Mix_FreeChunk(sound_steps[1]);
-	if (sound_steps[2])
-		Mix_FreeChunk(sound_steps[2]);
-	if (sound_steps[3])
-		Mix_FreeChunk(sound_steps[3]);
-	if (level_up)
-		Mix_FreeChunk(level_up);
+	Mix_FreeChunk(sound_melee);
+	Mix_FreeChunk(sound_hit);
+	Mix_FreeChunk(sound_die);
+	Mix_FreeChunk(sound_block);
+	Mix_FreeChunk(sound_steps[0]);
+	Mix_FreeChunk(sound_steps[1]);
+	Mix_FreeChunk(sound_steps[2]);
+	Mix_FreeChunk(sound_steps[3]);
+	Mix_FreeChunk(level_up);
 
 	delete haz;
 }

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -62,7 +62,7 @@ MenuActionBar::MenuActionBar(PowerManager *_powers, StatBlock *_hero, SDL_Surfac
 
 void MenuActionBar::update() {
 
-	// Read data from config file 
+	// Read data from config file
 	FileParser infile;
 	int counter = -1;
 	if (infile.open(mods->locate("menus/actionbar.txt"))) {
@@ -218,7 +218,7 @@ void MenuActionBar::loadGraphics() {
 	background = IMG_Load(mods->locate("images/menus/actionbar_trim.png").c_str());
 	disabled = IMG_Load(mods->locate("images/menus/disabled.png").c_str());
 	attention = IMG_Load(mods->locate("images/menus/attention_glow.png").c_str());
-	if(!emptyslot || !background || !disabled) {
+	if(!emptyslot || !background || !disabled || !attention) {
 		fprintf(stderr, "Couldn't load image: %s\n", IMG_GetError());
 		SDL_Quit();
 	}
@@ -537,6 +537,7 @@ MenuActionBar::~MenuActionBar() {
 	SDL_FreeSurface(emptyslot);
 	SDL_FreeSurface(background);
 	SDL_FreeSurface(disabled);
+	SDL_FreeSurface(attention);
 
 	for (unsigned int i=0; i<16; i++) {
 		delete labels[i];

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -677,8 +677,7 @@ MenuManager::~MenuManager() {
 	delete enemy;
 	delete effects;
 
-	if (sfx_open != NULL)
-		Mix_FreeChunk(sfx_open);
-	if (sfx_close != NULL)
-		Mix_FreeChunk(sfx_close);
+	Mix_FreeChunk(sfx_open);
+	Mix_FreeChunk(sfx_close);
+	SDL_FreeSurface(icons);
 }

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -59,6 +59,7 @@ MenuTalker::MenuTalker(CampaignManager *_camp) {
 
 void MenuTalker::loadGraphics() {
 
+	SDL_FreeSurface(background);
 	background = IMG_Load(mods->locate("images/menus/dialog_box.png").c_str());
 	if(!background) {
 		fprintf(stderr, "Couldn't load image dialog_box.png: %s\n", IMG_GetError());
@@ -69,7 +70,6 @@ void MenuTalker::loadGraphics() {
 	SDL_Surface *cleanup = background;
 	background = SDL_DisplayFormatAlpha(background);
 	SDL_FreeSurface(cleanup);
-
 }
 
 void MenuTalker::chooseDialogNode() {
@@ -234,6 +234,7 @@ void MenuTalker::render() {
 void MenuTalker::setHero(const string& name, const string& portrait_filename) {
 	hero_name = name;
 
+	SDL_FreeSurface(portrait);
 	portrait = IMG_Load(mods->locate("images/portraits/" + portrait_filename + ".png").c_str());
 	if(!portrait) {
 		fprintf(stderr, "Couldn't load portrait: %s\n", IMG_GetError());


### PR DESCRIPTION
Before assigning new values to SDL_Surface pointers, free them.
The same applies to Mix_Chunk.

Mix_FreeChunk ignores NULL pointers, so the userprogram may skip the check
for a pointer being null.
