### PR TITLE
On death, untransform player

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -565,7 +565,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			break;
 
 		case AVATAR_DEAD:
-			if (stats.transform_type != "") {
+			if (stats.transformed) {
 				stats.transform_duration = 0;
 				untransform();
 			}


### PR DESCRIPTION
Fixes two things:
1. when the player died while transformed, the "on death" log messages weren't shown
2. when they respawned, the player would still be transformed
