### PR TITLE
Don't allow transform when already transformed

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -298,6 +298,12 @@ void GameStatePlay::checkLog() {
 		menu->hudlog->add(menu->inv->log_msg);
 		menu->inv->log_msg = "";
 	}
+
+	// PowerManager has hints for powers
+	if (powers->log_msg != "") {
+		menu->hudlog->add(powers->log_msg);
+		powers->log_msg = "";
+	}
 }
 
 void GameStatePlay::checkEquipmentChange() {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -53,6 +53,8 @@ PowerManager::PowerManager() {
 
 	used_item=-1;
 
+	log_msg = "";
+
 	loadGraphics();
 	loadAll();
 }
@@ -1117,6 +1119,11 @@ bool PowerManager::spawn(const std::string& enemy_type, Point target) {
  * Transform into a creature. Fully replaces entity characteristics
  */
 bool PowerManager::transform(int power_index, StatBlock *src_stats, Point target) {
+
+	if (src_stats->transformed && powers[power_index].spawn_type != "untransform") {
+		log_msg = msg->get("You are already transformed, untransform first.");
+		return false;
+	}
 
 	// apply any buffs
 	buff(power_index, src_stats, target);

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -311,6 +311,8 @@ public:
 	PowerManager();
 	~PowerManager();
 
+	std::string log_msg;
+
 	void handleNewMap(MapCollision *_collider);
 	bool activate(int power_index, StatBlock *src_stats, Point target);
 	float calcTheta(int x1, int y1, int x2, int y2);


### PR DESCRIPTION
Discovered while testing Polymorphable. You can transform from shapeshifter to shapeshifter and savegame will save last state. But game doesn't pay attention on transformed_type changes if not "" or not "untransformed".
