### PR TITLE
Make saving current HP/MP an engine setting

### DIFF
--- a/mods/fantasycore/engine/misc.txt
+++ b/mods/fantasycore/engine/misc.txt
@@ -1,0 +1,3 @@
+# Miscellaneous engine settings
+
+save_hpmp=0

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -74,6 +74,9 @@ void GameStatePlay::saveGame() {
 		// current experience
 		outfile << "xp=" << pc->stats.xp << "\n";
 
+		// hp and mp
+		if (SAVE_HPMP) outfile << "hpmp=" << pc->stats.hp << "," << pc->stats.mp << "\n";
+
 		// stat spec
 		outfile << "build=" << pc->stats.physical_character << "," << pc->stats.mental_character << "," << pc->stats.offense_character << "," << pc->stats.defense_character << "\n";
 
@@ -126,6 +129,8 @@ void GameStatePlay::saveGame() {
  * When loading the game, load from file if possible
  */
 void GameStatePlay::loadGame() {
+	int saved_hp = 0;
+	int saved_mp = 0;
 
 	// game slots are currently 1-4
 	if (game_slot == 0) return;
@@ -153,6 +158,10 @@ void GameStatePlay::loadGame() {
 				pc->stats.portrait = infile.nextValue();
 			}
 			else if (infile.key == "xp") pc->stats.xp = atoi(infile.val.c_str());
+			else if (infile.key == "hpmp") {
+				saved_hp = atoi(infile.nextValue().c_str());
+				saved_mp = atoi(infile.nextValue().c_str());
+			}
 			else if (infile.key == "build") {
 				pc->stats.physical_character = atoi(infile.nextValue().c_str());
 				pc->stats.mental_character = atoi(infile.nextValue().c_str());
@@ -217,8 +226,10 @@ void GameStatePlay::loadGame() {
 	// initialize vars
 	pc->stats.recalc();
 	menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
-	pc->stats.hp = pc->stats.maxhp;
-	pc->stats.mp = pc->stats.maxmp;
+	if (saved_hp > 0) pc->stats.hp = saved_hp;
+	else pc->stats.hp = pc->stats.maxhp;
+	if (saved_mp > 0) pc->stats.mp = saved_mp;
+	else pc->stats.mp = pc->stats.maxmp;
 
 	// reset character menu
 	menu->chr->refreshStats();

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -117,6 +117,7 @@ bool AUTOPICKUP_GOLD = false;
 
 // Other Settings
 bool MENUS_PAUSE = false;
+bool SAVE_HPMP = false;
 
 
 /**
@@ -313,6 +314,22 @@ void loadAutoPickupSettings() {
 	}
 	else {
 		fprintf(stderr, "No autopickup config found! Turning autopickup off by default.\n");
+	}
+}
+
+void loadMiscSettings() {
+	FileParser infile;
+	// load autopickup settings from engine config
+	if (infile.open(mods->locate("engine/misc.txt").c_str())) {
+		while (infile.next()) {
+			if (infile.key == "save_hpmp") {
+				SAVE_HPMP = atoi(infile.val.c_str());
+			}
+		}
+		infile.close();
+	}
+	else {
+		fprintf(stderr, "No misc engine settings config found!\n");
 	}
 }
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -58,6 +58,7 @@ extern bool COMBAT_TEXT;
 
 // Engine Settings
 extern bool MENUS_PAUSE;
+extern bool SAVE_HPMP;
 
 // Tile Settings
 extern int UNITS_PER_TILE;
@@ -82,6 +83,7 @@ extern bool AUTOPICKUP_GOLD;
 void setPaths();
 void loadTilesetSettings();
 void loadAutoPickupSettings();
+void loadMiscSettings();
 bool loadSettings();
 bool saveSettings();
 bool loadDefaults();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,9 @@ static void init() {
     // Load autopickup settings (must be after ModManager is initialized)
     loadAutoPickupSettings();
 
+    // Load miscellaneous settings
+    loadMiscSettings();
+
 	// Add Window Titlebar Icon
 	titlebar_icon = IMG_Load(mods->locate("images/logo/icon.png").c_str());
 	SDL_WM_SetIcon(titlebar_icon, NULL);


### PR DESCRIPTION
Gives mod creators the option of saving HP/MP stats when saving. Polymorphable (which has zero autoregen) could benefit from this.
