### PR TITLE
Disable click to unlock for already unlocked powers

### DIFF
--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -293,6 +293,9 @@ bool MenuPowers::powerUnlockable(int power_index) {
 		}
 	}
 
+	// If we already have a power, don't try to unlock it
+	if (requirementsMet(power_index)) return false;
+
 	// Check requirements
 	if ((stats->physoff >= power_cell[id].requires_physoff) &&
 		(stats->physdef >= power_cell[id].requires_physdef) &&


### PR DESCRIPTION
Fixes being able to "unlock" the same power multiple times.
