### PR TITLE
Implement buyback tab for MenuVendor

### DIFF
--- a/src/CampaignManager.h
+++ b/src/CampaignManager.h
@@ -25,7 +25,6 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #define CAMPAIGN_MANAGER_H
 
 #include "ItemManager.h"
-#include "ItemStorage.h"
 
 #include <string>
 
@@ -59,7 +58,6 @@ public:
 	MenuItemStorage *carried_items;
 	int *currency;
 	StatBlock * hero;
-	ItemStorage buyback_stock;
 
 	bool quest_update;
 };

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -78,7 +78,6 @@ GameStatePlay::GameStatePlay() : GameState() {
 	camp->carried_items = &menu->inv->inventory[CARRIED];
 	camp->currency = &menu->inv->gold;
 	camp->hero = &pc->stats;
-	camp->buyback_stock.init(NPC_VENDOR_MAX_STOCK, items);
 	map->powers = powers;
 
 	// display the name of the map in the upper-right hand corner

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -38,6 +38,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "MenuActiveEffects.h"
 #include "MenuLog.h"
 #include "ModManager.h"
+#include "NPC.h"
 #include "PowerManager.h"
 #include "SharedResources.h"
 
@@ -64,7 +65,7 @@ MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManag
 	menus.push_back(act); // menus[5]
 	enemy = new MenuEnemy();
 	menus.push_back(enemy); // menus[6]
-	vendor = new MenuVendor(items, stats, camp);
+	vendor = new MenuVendor(items, stats);
 	menus.push_back(vendor); // menus[7]
 	talker = new MenuTalker(camp);
 	menus.push_back(talker); // menus[8]
@@ -132,6 +133,7 @@ MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManag
 	// Some menus need to be updated to apply their new dimensions
 	act->update();
 	vendor->update();
+	vendor->buyback_stock.init(NPC_VENDOR_MAX_STOCK, items);
 	talker->update();
 	exit->update();
 	chr->update();

--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -19,8 +19,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
  * class MenuVendor
  */
 
-#include "CampaignManager.h"
 #include "FileParser.h"
+#include "ItemStorage.h"
 #include "Menu.h"
 #include "MenuVendor.h"
 #include "NPC.h"
@@ -33,10 +33,9 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-MenuVendor::MenuVendor(ItemManager *_items, StatBlock *_stats, CampaignManager *_camp) {
+MenuVendor::MenuVendor(ItemManager *_items, StatBlock *_stats) {
 	items = _items;
 	stats = _stats;
-	camp = _camp;
 
 	visible = false;
 	talker_visible = false;
@@ -204,7 +203,7 @@ bool MenuVendor::full() {
 void MenuVendor::setInventory() {
 	for (int i=0; i<VENDOR_SLOTS; i++) {
 		stock[VENDOR_BUY][i] = npc->stock[i];
-		stock[VENDOR_SELL][i] = camp->buyback_stock[i];
+		stock[VENDOR_SELL][i] = buyback_stock[i];
 	}
 }
 
@@ -216,7 +215,7 @@ void MenuVendor::setInventory() {
 void MenuVendor::saveInventory() {
 	for (int i=0; i<VENDOR_SLOTS; i++) {
 		npc->stock[i] = stock[VENDOR_BUY][i];
-		camp->buyback_stock[i] = stock[VENDOR_SELL][i];
+		buyback_stock[i] = stock[VENDOR_SELL][i];
 	}
 
 }

--- a/src/MenuVendor.h
+++ b/src/MenuVendor.h
@@ -32,8 +32,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #define VENDOR_BUY 0
 #define VENDOR_SELL 1
 
-class CampaignManager;
 class InputState;
+class ItemStorage;
 class NPC;
 class StatBlock;
 class WidgetButton;
@@ -61,11 +61,11 @@ private:
 	int activetab;
 
 public:
-	MenuVendor(ItemManager *items, StatBlock *stats, CampaignManager *_camp);
+	MenuVendor(ItemManager *items, StatBlock *stats);
 	~MenuVendor();
 
 	NPC *npc;
-	CampaignManager *camp;
+	ItemStorage buyback_stock;
 
 	void update();
 	void loadMerchant(const std::string&);


### PR DESCRIPTION
The contents of the buyback tab are stored in the CampaignManager and carry over from vendor to vendor, even between maps. Exiting the game will clear the contents.
