### PR TITLE
Allow moving locked powers in ActionBar

### DIFF
--- a/mods/fantasycore/powers/powers.txt
+++ b/mods/fantasycore/powers/powers.txt
@@ -1,4 +1,5 @@
 # Power Definitions
+# Do not change power with id=136 called Disenchant
 
 [power]
 id=0

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -559,17 +559,20 @@ void GameStatePlay::logic() {
 		for (int i=0; i<12 ; i++) {
 			menu->act->actionbar[i] = menu->act->hotkeys[i];
 			menu->act->hotkeys[i] = -1;
-			menu->act->locked[i] = true;
 		}
 		int count = 10;
 		for (int i=0; i<4 ; i++) {
 			if (pc->charmed_stats->power_index[i] != -1) {
 				menu->act->hotkeys[count] = pc->charmed_stats->power_index[i];
+				menu->act->locked[count] = true;
 				count++;
 			}
 			if (count == 12) count = 0;
 		}
-		if (pc->stats.manual_untransform) menu->act->hotkeys[count] = 136; //untransform power
+		if (pc->stats.manual_untransform) {
+			menu->act->hotkeys[count] = 136; //untransform power
+			menu->act->locked[count] = true;
+		}
 	}
 	// revert hero powers
 	if (pc->revertPowers) {

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -422,10 +422,13 @@ TooltipData MenuActionBar::checkTooltip(Point mouse) {
 void MenuActionBar::drop(Point mouse, int power_index, bool rearranging) {
 	for (int i=0; i<12; i++) {
 		if (isWithin(slots[i], mouse)) {
-			if (locked[i] && hotkeys[i] != -1) return;
 			if (rearranging) {
+				if ((locked[i] && !locked[drag_prev_slot]) || (!locked[i] && locked[drag_prev_slot])) {
+					locked[i] = !locked[i];
+					locked[drag_prev_slot] = !locked[drag_prev_slot];
+				}
 				hotkeys[drag_prev_slot] = hotkeys[i];
-			}
+			} else if (locked[i]) return;
 			hotkeys[i] = power_index;
 			return;
 		}
@@ -488,7 +491,6 @@ int MenuActionBar::checkDrag(Point mouse) {
 
 	for (int i=0; i<12; i++) {
 		if (isWithin(slots[i], mouse)) {
-			if (locked[i]) return -1;
 			drag_prev_slot = i;
 			power_index = hotkeys[i];
 			hotkeys[i] = -1;

--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -80,7 +80,7 @@ public:
 
 	int hotkeys[12]; // refer to power_index in PowerManager
 	int actionbar[12]; // temp for shapeshifting
-	bool locked[12]; // if slot is locked, you cannot drop or replace it
+	bool locked[12]; // if slot is locked, you cannot drop it
 	SDL_Rect slots[12]; // the location of hotkey slots
 	SDL_Rect menus[4]; // the location of the menu buttons
 	int slot_item_count[12]; // -1 means this power isn't item based.  0 means out of items.  1+ means sufficient items.

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -466,7 +466,7 @@ void MenuManager::logic() {
 				inpt->lock[MAIN1] = true;
 
 				// ctrl-click action bar to clear that slot
-				if (inpt->pressing[CTRL] && !stats->transformed) {
+				if (inpt->pressing[CTRL]) {
 					act->remove(inpt->mouse);
 				}
 				// allow drag-to-rearrange action bar
@@ -499,6 +499,9 @@ void MenuManager::logic() {
 			else if (drag_src == DRAG_SRC_ACTIONBAR) {
 				if (isWithin(act->numberArea,inpt->mouse) || isWithin(act->mouseArea,inpt->mouse)) {
 					act->drop(inpt->mouse, drag_power, 1);
+				// for locked slots forbid power dropping
+				} else if (act->locked[act->drag_prev_slot]) {
+					act->hotkeys[act->drag_prev_slot] = drag_power;
 				}
 			}
 


### PR DESCRIPTION
Changed a little locked slots behavior. They can be rearranged, but not dropped.
