### PR TITLE
Allow enemies to wander randomly in a rectanglular area

### DIFF
--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -66,6 +66,12 @@ void BehaviorStandard::doUpkeep() {
 	if (e->stats.waypoint_pause_ticks > 0)
 		e->stats.waypoint_pause_ticks--;
 
+	if (e->stats.wander_ticks > 0)
+		e->stats.wander_ticks--;
+
+	if (e->stats.wander_pause_ticks > 0)
+		e->stats.wander_pause_ticks--;
+
 	// check for bleeding to death
 	if (e->stats.hp <= 0 && !(e->stats.cur_state == ENEMY_DEAD || e->stats.cur_state == ENEMY_CRITDEAD)) {
 		e->doRewards();
@@ -144,16 +150,24 @@ void BehaviorStandard::findTarget() {
 		e->stats.in_combat = false;
 	}
 
-	// by default, the enemy pursues the hero directly
-	pursue_pos.x = e->stats.hero_pos.x;
-	pursue_pos.y = e->stats.hero_pos.y;
+	// if the creature is a wanderer, pick a random point within the wander area to travel to
+	if (e->stats.wander && !e->stats.in_combat) {
+		if (e->stats.wander_ticks == 0) {
+			pursue_pos.x = e->stats.wander_area.x + (rand() % (e->stats.wander_area.w));
+			pursue_pos.y = e->stats.wander_area.y + (rand() % (e->stats.wander_area.h));
+			e->stats.wander_ticks = (rand() % 150) + 150;
+		}
+	} else {
+		// by default, the enemy pursues the hero directly
+		pursue_pos.x = e->stats.hero_pos.x;
+		pursue_pos.y = e->stats.hero_pos.y;
 
-	if (!(e->stats.in_combat || e->stats.waypoints.empty())) {
-	    Point waypoint = e->stats.waypoints.front();
-	    pursue_pos.x = waypoint.x;
-	    pursue_pos.y = waypoint.y;
+		if (!(e->stats.in_combat || e->stats.waypoints.empty())) {
+			Point waypoint = e->stats.waypoints.front();
+			pursue_pos.x = waypoint.x;
+			pursue_pos.y = waypoint.y;
+		}
 	}
-
 }
 
 
@@ -240,7 +254,7 @@ void BehaviorStandard::checkMove() {
 	if (e->stats.stun_duration) return;
 
 	// handle not being in combat and (not patrolling waypoints or waiting at waypoint)
-	if (!e->stats.in_combat && (e->stats.waypoints.empty() || e->stats.waypoint_pause_ticks > 0)) {
+	if (!e->stats.in_combat && (e->stats.waypoints.empty() || e->stats.waypoint_pause_ticks > 0) && (!e->stats.wander || e->stats.wander_pause_ticks > 0)) {
 
 		if (e->stats.cur_state == ENEMY_MOVE) {
 			e->newState(ENEMY_STANCE);
@@ -327,6 +341,17 @@ void BehaviorStandard::checkMove() {
 	        e->stats.waypoints.push(waypoint);
 	        e->stats.waypoint_pause_ticks = e->stats.waypoint_pause;
 	    }
+	}
+
+	// if a wandering enemy reaches its destination early, reset wander_ticks
+	if (e->stats.wander) {
+	    Point pos = e->stats.pos;
+	    if (abs(pursue_pos.x - pos.x) < UNITS_PER_TILE/2 && abs(pursue_pos.y - pos.y) < UNITS_PER_TILE/2) {
+			e->stats.wander_ticks = 0;
+		}
+		if (e->stats.wander_ticks == 0 && e->stats.wander_pause_ticks == 0) {
+			e->stats.wander_pause_ticks = rand() % 60;
+		}
 	}
 
 	// re-block current space to allow correct movement

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -145,6 +145,8 @@ void EnemyManager::handleNewMap () {
 		e->stats.pos.x = me.pos.x;
 		e->stats.pos.y = me.pos.y;
 		e->stats.direction = me.direction;
+		e->stats.wander = me.wander;
+		e->stats.wander_area = me.wander_area;
 		e->stats.load("enemies/" + me.type + ".txt");
 		if (e->stats.animations != "") {
 			// load the animation file if specified

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -264,6 +264,12 @@ int MapRenderer::load(string filename) {
 						a = infile.nextValue();
 						b = infile.nextValue();
 					}
+				} else if (infile.key == "wander_area") {
+					new_enemy.wander = true;
+					new_enemy.wander_area.x = atoi(infile.nextValue().c_str()) * UNITS_PER_TILE + UNITS_PER_TILE / 2;
+					new_enemy.wander_area.y = atoi(infile.nextValue().c_str()) * UNITS_PER_TILE + UNITS_PER_TILE / 2;
+					new_enemy.wander_area.w = atoi(infile.nextValue().c_str()) * UNITS_PER_TILE + UNITS_PER_TILE / 2;
+					new_enemy.wander_area.h = atoi(infile.nextValue().c_str()) * UNITS_PER_TILE + UNITS_PER_TILE / 2;
 				}
 			}
 			else if (infile.section == "enemygroup") {

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -132,6 +132,8 @@ public:
 	Point pos;
 	int direction;
 	std::queue<Point> waypoints;
+	bool wander;
+	SDL_Rect wander_area;
 
 	void clear() {
 		pos.x = 0;
@@ -141,6 +143,11 @@ public:
 		type = "";
 		std::queue<Point> empty;
 		waypoints = empty;
+		wander = false;
+		wander_area.x = 0;
+		wander_area.y = 0;
+		wander_area.w = 0;
+		wander_area.h = 0;
 	}
 };
 

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -114,6 +114,11 @@ StatBlock::StatBlock() {
 	waypoint_pause = 0;
 	waypoint_pause_ticks = 0;
 
+	// wandering
+	wander= false;
+	wander_ticks = 0;
+	wander_pause_ticks = 0;
+
 	// xp table
 	// default to MAX_INT
 	for (int i=0; i<MAX_CHARACTER_LEVEL; i++) {

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -224,6 +224,12 @@ public:
     int waypoint_pause;
     int waypoint_pause_ticks;
 
+	// wandering area
+	bool wander;
+	SDL_Rect wander_area;
+	int wander_ticks;
+	int wander_pause_ticks;
+
 	// enemy behavioral stats
 	int chance_pursue;
 	int chance_flee;


### PR DESCRIPTION
To use this feature, add the following to an [enemy] definition in a map file:

```
wander_area=48,48,4,4
```

The first two values are the x and y values corresponding to the top-left tile of the rectangle. The next two values are the width and height of that rectangle (in tiles).
