### PR TITLE
Initialize variables for enemy groups

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -115,6 +115,7 @@ void MapRenderer::push_enemy_group(Map_Group g) {
 		Enemy_Level enemy_lev = EnemyGroupManager::instance().getRandomEnemy(g.category, g.levelmin, g.levelmax);
 		Map_Enemy group_member;
 		if ((enemy_lev.type != "") && (valid_locations.size() != 0)){
+			group_member.clear();
 			group_member.type = enemy_lev.type;
 			int index = rand() % valid_locations.size();
 			group_member.pos = valid_locations.at(index);


### PR DESCRIPTION
Enemy groups weren't having their wander bool initialized, so wander-related code was still being run for any enemies in an enemy group. This should hopefully solve #746.
