### PR TITLE
Make sure all menus start closed

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -159,6 +159,8 @@ MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManag
 	loadSounds();
 
 	done = false;
+
+	closeAll(false); // make sure all togglable menus start closed
 }
 
 /**


### PR DESCRIPTION
Sometimes when I switched saves, different menus would start opened (usually stash and inventory). This just makes sure that doesn't happen.
