### PR TITLE
Add bonus_per_* to powers

### DIFF
--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -374,6 +374,20 @@ void PowerManager::loadPowers(const std::string& filename) {
 			else if (infile.key == "target_neighbor") {
 				powers[input_id].target_neighbor = atoi(infile.val.c_str());
 			}
+
+			// stat bonues
+			else if (infile.key == "bonus_per_physical") {
+				powers[input_id].bonus_per_physical = atoi(infile.val.c_str());
+			}
+			else if (infile.key == "bonus_per_mental") {
+				powers[input_id].bonus_per_mental = atoi(infile.val.c_str());
+			}
+			else if (infile.key == "bonus_per_offense") {
+				powers[input_id].bonus_per_offense = atoi(infile.val.c_str());
+			}
+			else if (infile.key == "bonus_per_defense") {
+				powers[input_id].bonus_per_defense = atoi(infile.val.c_str());
+			}
 		}
 		infile.close();
 	}
@@ -639,6 +653,10 @@ void PowerManager::initHazard(int power_index, StatBlock *src_stats, Point targe
 	haz->dmg_min = (int)ceil(haz->dmg_min * powers[power_index].damage_multiplier / 100.0);
 	haz->dmg_max = (int)ceil(haz->dmg_max * powers[power_index].damage_multiplier / 100.0);
 
+	//apply stat bonuses
+	haz->dmg_min = haz->dmg_min + (src_stats->get_physical() * powers[power_index].bonus_per_physical) + (src_stats->get_mental() * powers[power_index].bonus_per_mental) + (src_stats->get_offense() * powers[power_index].bonus_per_offense) + (src_stats->get_defense() * powers[power_index].bonus_per_defense);
+	haz->dmg_max = haz->dmg_max + (src_stats->get_physical() * powers[power_index].bonus_per_physical) + (src_stats->get_mental() * powers[power_index].bonus_per_mental) + (src_stats->get_offense() * powers[power_index].bonus_per_offense) + (src_stats->get_defense() * powers[power_index].bonus_per_defense);
+
 	// Only apply stats from powers that are not defaults
 	// If we do this, we can init with multiple power layers
 	// (e.g. base spell plus weapon type)
@@ -774,8 +792,8 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 	// heal for ment weapon damage * damage multiplier
 	if (powers[power_index].buff_heal) {
 		int heal_amt = 0;
-		int heal_max = (int)ceil(src_stats->dmg_ment_max * powers[power_index].damage_multiplier / 100.0);
-		int heal_min = (int)ceil(src_stats->dmg_ment_min * powers[power_index].damage_multiplier / 100.0);
+		int heal_max = (int)ceil(src_stats->dmg_ment_max * powers[power_index].damage_multiplier / 100.0) + (src_stats->get_physical() * powers[power_index].bonus_per_physical) + (src_stats->get_mental() * powers[power_index].bonus_per_mental) + (src_stats->get_offense() * powers[power_index].bonus_per_offense) + (src_stats->get_defense() * powers[power_index].bonus_per_defense);
+		int heal_min = (int)ceil(src_stats->dmg_ment_min * powers[power_index].damage_multiplier / 100.0) + (src_stats->get_physical() * powers[power_index].bonus_per_physical) + (src_stats->get_mental() * powers[power_index].bonus_per_mental) + (src_stats->get_offense() * powers[power_index].bonus_per_offense) + (src_stats->get_defense() * powers[power_index].bonus_per_defense);
 		if (heal_max > heal_min)
 			heal_amt = rand() % (heal_max - heal_min) + heal_min;
 		else // avoid div by 0
@@ -799,7 +817,7 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 
 	// charge shield to max ment weapon damage * damage multiplier
 	if (powers[power_index].buff_shield) {
-	    int shield_amt = (int)ceil(src_stats->dmg_ment_max * powers[power_index].damage_multiplier / 100.0);
+	    int shield_amt = (int)ceil(src_stats->dmg_ment_max * powers[power_index].damage_multiplier / 100.0) + (src_stats->get_physical() * powers[power_index].bonus_per_physical) + (src_stats->get_mental() * powers[power_index].bonus_per_mental) + (src_stats->get_offense() * powers[power_index].bonus_per_offense) + (src_stats->get_defense() * powers[power_index].bonus_per_defense);
 	    CombatText::Instance()->addMessage(shield_amt, src_stats->pos, DISPLAY_SHIELD);
 		src_stats->shield_hp = src_stats->shield_hp_total = shield_amt;
 	}

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -137,6 +137,10 @@ public:
 	int forced_move_speed;
 	int forced_move_duration;
 	int range;
+	int bonus_per_physical;
+	int bonus_per_mental;
+	int bonus_per_offense;
+	int bonus_per_defense;
 
 	//steal effects (in %, eg. hp_steal=50 turns 50% damage done into HP regain.)
 	int hp_steal;
@@ -275,6 +279,11 @@ public:
 		spawn_type = "";
 		spawn_num = 1;
 		target_neighbor = 0;
+
+		bonus_per_physical = 0;
+		bonus_per_mental = 0;
+		bonus_per_offense = 0;
+		bonus_per_defense = 0;
 	}
 
 };


### PR DESCRIPTION
For issue #776. This allows adding flat bonuses based on major stats (physical, mental, offense, defense) to powers.
