### PR TITLE
Do not load sound and music, if respective volume is zero.

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -178,7 +178,7 @@ void Avatar::loadGraphics(const string& _img_main, string _img_armor, const stri
 }
 
 void Avatar::loadSounds() {
-	if (audio) {
+	if (audio && SOUND_VOLUME) {
 		Mix_FreeChunk(sound_melee);
 		Mix_FreeChunk(sound_hit);
 		Mix_FreeChunk(sound_die);
@@ -215,7 +215,7 @@ void Avatar::loadStepFX(const string& stepname) {
 	}
 
 	// load new sounds
-	if (audio == true) {
+	if (audio && SOUND_VOLUME) {
 		sound_steps[0] = Mix_LoadWAV(mods->locate("soundfx/steps/step_" + filename + "1.ogg").c_str());
 		sound_steps[1] = Mix_LoadWAV(mods->locate("soundfx/steps/step_" + filename + "2.ogg").c_str());
 		sound_steps[2] = Mix_LoadWAV(mods->locate("soundfx/steps/step_" + filename + "3.ogg").c_str());

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -85,7 +85,7 @@ void EnemyManager::loadSounds(const string& type_id) {
         }
     }
 
-    if (audio == true) {
+    if (audio && SOUND_VOLUME) {
         sound_phys[sfx_count] = Mix_LoadWAV(mods->locate("soundfx/enemies/" + type_id + "_phys.ogg").c_str());
         sound_ment[sfx_count] = Mix_LoadWAV(mods->locate("soundfx/enemies/" + type_id + "_ment.ogg").c_str());
         sound_hit[sfx_count] = Mix_LoadWAV(mods->locate("soundfx/enemies/" + type_id + "_hit.ogg").c_str());

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -46,7 +46,7 @@ GameSwitcher::GameSwitcher() {
 
 void GameSwitcher::loadMusic() {
 
-    if (audio == true) {
+    if (audio && MUSIC_VOLUME) {
         music = Mix_LoadMUS((mods->locate("music/title_theme.ogg")).c_str());
         if (!music)
           printf("Mix_LoadMUS: %s\n", Mix_GetError());

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -235,7 +235,7 @@ void ItemManager::load(const string& filename) {
 void ItemManager::loadSounds() {
 	memset(sfx, 0, sizeof(sfx));
 
-	if (audio) {
+	if (audio && SOUND_VOLUME) {
 		sfx[SFX_BOOK] = Mix_LoadWAV(mods->locate("soundfx/inventory/inventory_book.ogg").c_str());
 		sfx[SFX_CLOTH] = Mix_LoadWAV(mods->locate("soundfx/inventory/inventory_cloth.ogg").c_str());
 		sfx[SFX_COINS] = Mix_LoadWAV(mods->locate("soundfx/inventory/inventory_coins.ogg").c_str());

--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -92,7 +92,7 @@ LootManager::LootManager(ItemManager *_items, MapRenderer *_map, StatBlock *_her
 
 	loadGraphics();
 	calcTables();
-	if (audio == true)
+	if (audio && SOUND_VOLUME)
 		loot_flip = Mix_LoadWAV(mods->locate("soundfx/flying_loot.ogg").c_str());
 	full_msg = false;
 

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -564,7 +564,7 @@ void MapRenderer::loadMusic() {
 		Mix_FreeMusic(music);
 		music = NULL;
 	}
-	if (audio == true) {
+	if (audio && MUSIC_VOLUME) {
 		music = Mix_LoadMUS((mods->locate("music/" + this->music_filename)).c_str());
 		if(!music)
 			printf("Mix_LoadMUS: %s\n", Mix_GetError());

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -181,7 +181,7 @@ void MenuManager::loadIcons() {
 }
 
 void MenuManager::loadSounds() {
-	if (audio == true) {
+	if (audio && SOUND_VOLUME) {
 		sfx_open = Mix_LoadWAV(mods->locate("soundfx/inventory/inventory_page.ogg").c_str());
 		sfx_close = Mix_LoadWAV(mods->locate("soundfx/inventory/inventory_book.ogg").c_str());
 

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -212,7 +212,7 @@ void NPC::loadGraphics(const string& filename_sprites, const string& filename_po
  */
 void NPC::loadSound(const string& filename, int type) {
 
-	if (type == NPC_VOX_INTRO) {
+	if (type == NPC_VOX_INTRO && SOUND_VOLUME) {
 
 		// if too many already loaded, skip this one
 		if (audio) {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -434,7 +434,7 @@ int PowerManager::loadSFX(const string& filename) {
         }
 
         // we don't already have this sound loaded, so load it
-        if (audio ==  true) {
+        if (audio && SOUND_VOLUME) {
             sfx[sfx_count] = Mix_LoadWAV(mods->locate("soundfx/powers/" + filename).c_str());
             if(!sfx[sfx_count]) {
                 fprintf(stderr, "Couldn't load power soundfx: %s\n", filename.c_str());


### PR DESCRIPTION
Closes #780.

Tested and works without errors nor warnings.

By the way: 
SDL is a rather friendly library as it will not crash if handing over the wrong parameters.
If there is some code like this:

```
    Mix_Chunk *sound = NULL;
    channel = Mix_PlayChannel(-1, sound, 0);
    if(channel == -1) {
        printf("Unable to play WAV file: %s\n", Mix_GetError());
    }
```

the result is just:

```
Unable to play WAV file: Tried to play a NULL chunk
```
