### PR TITLE
Allow arbitrary slot positioning for MenuItems

### DIFF
--- a/mods/fantasycore/menus/inventory.txt
+++ b/mods/fantasycore/menus/inventory.txt
@@ -5,7 +5,13 @@
 close=294,2
 help=2,2,24,24
 
-equipped_area=32,48,256,64
+# define x,y position, slot type, slot description/name
+equipment_slot=32,48,main,Main Hand
+equipment_slot=96,48,body,Body
+equipment_slot=160,48,off,Off Hand
+equipment_slot=224,48,artifact,Artifact
+
+equipment_slots=4
 carried_area=32,128
 carried_cols=8
 carried_rows=8

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -39,8 +39,6 @@ class WidgetButton;
 const int EQUIPMENT = 0;
 const int CARRIED = 1;
 
-const int MAX_EQUIPPED = 4;
-
 enum InventorySlotsType {
 	SLOT_MAIN = 0,
 	SLOT_BODY = 1,
@@ -62,15 +60,12 @@ private:
 	SDL_Surface *background;
 	WidgetButton *closeButton;
 
+	int MAX_EQUIPPED;
 	int MAX_CARRIED;
 
 	// label and widget positions
 	Point close_pos;
 	LabelInfo title;
-	LabelInfo main_lbl;
-	LabelInfo body_lbl;
-	LabelInfo off_lbl;
-	LabelInfo artifact_lbl;
 	LabelInfo gold_lbl;
 	SDL_Rect help_pos;
 	int carried_cols;
@@ -107,7 +102,9 @@ public:
 	bool visible;
 
 	SDL_Rect carried_area;
-	SDL_Rect equipped_area;
+	std::vector<SDL_Rect> equipped_area;
+	std::vector<std::string> slot_type;
+	std::vector<std::string> slot_desc;
 
 	MenuItemStorage inventory[2];
 	int gold;

--- a/src/MenuItemStorage.cpp
+++ b/src/MenuItemStorage.cpp
@@ -26,27 +26,48 @@ using namespace std;
 
 void MenuItemStorage::init(int _slot_number, ItemManager *_items, SDL_Rect _area, int _icon_size, int _nb_cols) {
 	ItemStorage::init( _slot_number, _items);
-	area = _area;
+	area.push_back(_area);
 	icon_size = _icon_size;
 	nb_cols = _nb_cols;
 	drag_prev_slot = -1;
 }
 
+/**
+ * Overloaded function for case, if slot positions are predefined
+ */
+void MenuItemStorage::init(int _slot_number, ItemManager *_items, vector<SDL_Rect> _area, int _icon_size, vector<string> _slot_type) {
+	ItemStorage::init( _slot_number, _items);
+	area = _area;
+	icon_size = _icon_size;
+	nb_cols = 0;
+	slot_type = _slot_type;
+	drag_prev_slot = -1;
+	if ((slot_type.size() != (unsigned)slot_number) || (area.size() != (unsigned)slot_number)) {
+		fprintf(stderr, "Slots number doesn't match slots area or slots type number. Check your menus/inventory.txt\n");
+		SDL_Quit();
+	}
+}
+
 void MenuItemStorage::render() {
 	for (int i=0; i<slot_number; i++) {
-		if (storage[i].item > 0) {
-			items->renderIcon(storage[i], area.x + (i % nb_cols * icon_size), area.y + (i / nb_cols * icon_size), icon_size);
-		}	
+		if (storage[i].item > 0 && nb_cols > 0) {
+			items->renderIcon(storage[i], area[0].x + (i % nb_cols * icon_size), area[0].y + (i / nb_cols * icon_size), icon_size);
+		} else if (storage[i].item > 0 && nb_cols == 0) {
+			items->renderIcon(storage[i], area[i].x, area[i].y, icon_size);
+		}
 	}
 }
 
 int MenuItemStorage::slotOver(Point mouse) {
-	if( isWithin( area, mouse)) {
-		return (mouse.x - area.x) / icon_size + (mouse.y - area.y) / icon_size * nb_cols;
+	if (isWithin(area[0], mouse) && nb_cols > 0) {
+		return (mouse.x - area[0].x) / icon_size + (mouse.y - area[0].y) / icon_size * nb_cols;
 	}
-	else {
-		return -1;
+	else if (nb_cols == 0) {
+		for (unsigned int i=0; i<area.size(); i++) {
+			if (isWithin(area[i], mouse)) return i;
+		}
 	}
+	return -1;
 }
 
 TooltipData MenuItemStorage::checkTooltip(Point mouse, StatBlock *stats, bool vendor_view) {

--- a/src/MenuItemStorage.h
+++ b/src/MenuItemStorage.h
@@ -31,12 +31,14 @@ class TooltipData;
 
 class MenuItemStorage : public ItemStorage {
 protected:
-	SDL_Rect area;
+	std::vector<SDL_Rect> area;
 	int icon_size;
 	int nb_cols;
+	std::vector<std::string> slot_type;
 
 public:
 	void init(int _slot_number, ItemManager *_items, SDL_Rect _area, int icon_size, int nb_cols);
+	void init(int _slot_number, ItemManager *_items, std::vector<SDL_Rect> _area, int icon_size, std::vector<std::string> _slot_type);
 
 	// rendering
 	void render();


### PR DESCRIPTION
- MenuItemStorage::init was reloaded to build slots area with arbitrary positioned slots(in contrast to current "rectangular" implementation).
- Equipped slots in MenuInventory was moved to new layout.
