### PR TITLE
Animations: Fix type warning messages.

### DIFF
--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -151,18 +151,20 @@ void Entity::loadAnimations(const string& filename) {
 	string type = "";
 	string firstAnimation = "";
 	int active_frame = 0;
+	bool first_section=true;
 
 	// Parse the file and on each new section create an animation object from the data parsed previously
-
 	parser.next();
-	parser.new_section = false; // do not create the first animation object until parser has parsed first section
 
 	do {
 		// create the animation if finished parsing a section
 		if (parser.new_section) {
-			Animation *a = new Animation();
-			a->init(name, render_size, render_offset,  position, frames, duration, type, active_frame);
-			animations.push_back(a);
+			if (!first_section) {
+				Animation *a = new Animation();
+				a->init(name, render_size, render_offset,  position, frames, duration, type, active_frame);
+				animations.push_back(a);
+			}
+			first_section = false;
 		}
 
 		if (parser.key == "position") {


### PR DESCRIPTION
Fixes #832.

A new animation is created when the previous section is complete.
That's exactly the case when a new section starts:
parser.new_section is set. But it is not the case when dealing with the
very first section, because there we have no section before which should
be added.

I suspect that the line setting back "parser.new_section = false;" after
reading the first line should have prevented the case, but that would only
work if the first section started in the first line.
If we have a layout of animation config files like the following, in which
we configure some common things for all sections, the previous solution
would not work:

```
render_size_x=128
render_size_y=128
render_offset_x=64
render_offset_y=96

[stance]
position=0
frames=4
duration=180
type=back_forth

[run]
position=4
...
```
