### PR TITLE
fix segfault when right clicking a quest item

### DIFF
--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -363,8 +363,12 @@ void MenuInventory::activate(InputState * input) {
 	// clicked a carried item
 	slot = inventory[CARRIED].slotOver(input->mouse);
 
+	// can't interact with quest items
+	if (items->items[inventory[CARRIED][slot].item].type == "quest") {
+		return;
+	}
 	// use a consumable item
-	if (items->items[inventory[CARRIED][slot].item].type == "consumable") {
+	else if (items->items[inventory[CARRIED][slot].item].type == "consumable") {
 
 		//don't use untransform item if hero is not transformed
 		if (powers->powers[items->items[inventory[CARRIED][slot].item].power].spawn_type == "untransform" && !stats->transformed) return;


### PR DESCRIPTION
Quest items should be explicitly handled (AKA ignored) when the player "activates" them in their inventory.

Otherwise the game goes ahead and looks up the quest item's equipment slot, which returns -1, and gets an invalid array access, causing a sad face to appear on this player's face.
