### PR TITLE
Language

### DIFF
--- a/mods/fantasycore/engine/languages.txt
+++ b/mods/fantasycore/engine/languages.txt
@@ -1,16 +1,16 @@
 # If default font should be overriden, specify it's filename and ptsize
 en=English
 be=Беларуская
-fi=Suomi
+de=Deutsch
+el=Ελληνικά
+es=Español
 fr=Français
 it=Italiano
 gl=Galego
-de=Deutsch
-el=Ελληνικά
-ja=日本語,unifont-5.1.ttf,12
 nl=Nederlands
+ja=Nihongo,unifont-5.1.ttf,12
 ru=Русский
 sk=Slovenčina
-es=Español
+fi=Suomi
 sv=Svenska
 uk=Українська


### PR DESCRIPTION
Okay, so I added Dutch to languages.txt.

But with a twist: I propose to translate the languages that can be selected as well.

I have done this in this merge request. The translations of the languages are based on Wikipedia languages. 

Japanese characters are not rendered in the default font, so I added Japanese in rōmaji (latin chacaters).

I feel that the language selection merges better into the translated environment that way. (I also have an engine.nl.po now, will commit that later).

What do you think?
