### PR TITLE
Added Dutch translation to Fantasycore mod engine

### DIFF
--- a/mods/fantasycore/languages/engine.nl.po
+++ b/mods/fantasycore/languages/engine.nl.po
@@ -1,0 +1,825 @@
+# Copyright (C) 2012 Bas Doodeman
+# This file is distributed under the same license as the Flare package.
+#
+# Bas Doodeman <bas.doodeman@basdoodeman.nl>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 0.16\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2012-06-30 19:20+0700\n"
+"PO-Revision-Date: 2012-08-23 21:23+0200\n"
+"Last-Translator: Bas Doodeman <bas.doodeman@basdoodeman.nl>\n"
+"Language-Team: Dutch; Flemish <>\n"
+"Language: Dutch\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bits\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: ../../../src/Avatar.cpp:389
+#, c-format
+msgid "Congratulations, you have reached level %d!"
+msgstr "Gefeliciteerd, je hebt niveau %d bereikt!"
+
+#: ../../../src/Avatar.cpp:391
+msgid "You may increase one attribute through the Character Menu."
+msgstr "Je kunt één eigenschap in het karakter menu verhogen."
+
+#: ../../../src/Avatar.cpp:572
+msgid "You are defeated. Game over! Press Enter to exit to Title."
+msgstr "Je bent verslagen. Spel afgelopen! Druk op Enter, om naar het hoofdmenu terug te keren."
+
+#: ../../../src/Avatar.cpp:575
+msgid "You are defeated.  You lose half your gold.  Press Enter to continue."
+msgstr "Je bent verslagen.  Je verliest de helft van je goud.  Druk op Enter om verder te gaan."
+
+#: ../../../src/CampaignManager.cpp:149
+#, c-format
+msgid "You receive %s."
+msgstr "Je ontvangt %s."
+
+#: ../../../src/CampaignManager.cpp:151
+#, c-format
+msgid "You receive %s x%d."
+msgstr "Je ontvangt %s x%d."
+
+#: ../../../src/CampaignManager.cpp:159
+#, c-format
+msgid "You receive %d gold."
+msgstr "Je ontvangt %d goud."
+
+#: ../../../src/CampaignManager.cpp:165
+#, c-format
+msgid "You receive %d XP."
+msgstr "Je ontvangt %d EP."
+
+#: ../../../src/GameStateConfig.cpp:72 ../../../src/GameStateConfig.cpp:689
+#: ../../../src/GameStateConfig.cpp:691
+msgid "Press a key to assign: "
+msgstr "Druk een toets om toe te kennen: "
+
+#: ../../../src/GameStateConfig.cpp:73 ../../../src/GameStateConfig.cpp:258
+msgid "Defaults"
+msgstr "Standaardwaarden"
+
+#: ../../../src/GameStateConfig.cpp:73
+msgid "Set ALL settings to default?"
+msgstr "ALLE instellingen terugzetten op de standaardwaarden?"
+
+#: ../../../src/GameStateConfig.cpp:243
+msgid "Video"
+msgstr "Video"
+
+#: ../../../src/GameStateConfig.cpp:244
+msgid "Audio"
+msgstr "Audio"
+
+#: ../../../src/GameStateConfig.cpp:245
+msgid "Interface"
+msgstr "Omgeving"
+
+#: ../../../src/GameStateConfig.cpp:246
+msgid "Input"
+msgstr "Invoer"
+
+#: ../../../src/GameStateConfig.cpp:247
+msgid "Keybindings"
+msgstr "Sneltoetsen"
+
+#: ../../../src/GameStateConfig.cpp:248
+msgid "Mods"
+msgstr "Mods"
+
+#: ../../../src/GameStateConfig.cpp:252
+msgid "Ok"
+msgstr "Accepteren"
+
+#: ../../../src/GameStateConfig.cpp:264 ../../../src/GameStateNew.cpp:48
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: ../../../src/GameStateConfig.cpp:270
+msgid "Full Screen Mode"
+msgstr "Volledig scherm"
+
+#: ../../../src/GameStateConfig.cpp:278
+msgid "Music Volume"
+msgstr "Muziekvolume"
+
+#: ../../../src/GameStateConfig.cpp:286
+msgid "Sound Volume"
+msgstr "Geluidsvolume"
+
+#: ../../../src/GameStateConfig.cpp:294
+msgid "Gamma"
+msgstr "Gammacorrectie"
+
+#: ../../../src/GameStateConfig.cpp:302
+msgid "Move hero using mouse"
+msgstr "Muisbesturing"
+
+#: ../../../src/GameStateConfig.cpp:310
+msgid "Show combat text"
+msgstr "Laat strijdtekst zien"
+
+#: ../../../src/GameStateConfig.cpp:318
+msgid "Hardware surfaces"
+msgstr "Hardware oppervlakken"
+
+#: ../../../src/GameStateConfig.cpp:326
+msgid "Double buffering"
+msgstr "Dubbele buffering"
+
+#: ../../../src/GameStateConfig.cpp:334
+msgid "Use joystick"
+msgstr "Gebruik de Joystick"
+
+#: ../../../src/GameStateConfig.cpp:342 ../../../src/GameStateConfig.cpp:346
+msgid "Try disabling for performance"
+msgstr "Uitschakelen kan presaties verbeteren"
+
+#: ../../../src/GameStateConfig.cpp:352
+msgid "Resolution"
+msgstr "Resolutie"
+
+#: ../../../src/GameStateConfig.cpp:360
+msgid "Language"
+msgstr "Taal"
+
+#: ../../../src/GameStateConfig.cpp:368
+msgid "Joystick"
+msgstr "Joystick"
+
+#: ../../../src/GameStateConfig.cpp:393
+msgid "Active Mods"
+msgstr "Actieve Mods"
+
+#: ../../../src/GameStateConfig.cpp:404
+msgid "Avaliable Mods"
+msgstr "Beschikbare Mods"
+
+#: ../../../src/GameStateConfig.cpp:416
+msgid "<< Deactivate"
+msgstr "<< Deactiveren"
+
+#: ../../../src/GameStateConfig.cpp:417
+msgid "Activate >>"
+msgstr "Activeren >>"
+
+#: ../../../src/GameStateLoad.cpp:48 ../../../src/GameStateLoad.cpp:63
+msgid "Delete Save"
+msgstr "Spel verwijderen"
+
+#: ../../../src/GameStateLoad.cpp:48
+msgid "Delete this save?"
+msgstr "Dit spel werkelijk verwijderen?"
+
+#: ../../../src/GameStateLoad.cpp:50
+msgid "Exit to Title"
+msgstr "Terug naar het menu"
+
+#: ../../../src/GameStateLoad.cpp:56
+msgid "Choose a Slot"
+msgstr "Kies een Slot"
+
+#: ../../../src/GameStateLoad.cpp:326 ../../../src/GameStateLoad.cpp:343
+msgid "New Game"
+msgstr "New Spel"
+
+#: ../../../src/GameStateLoad.cpp:347
+msgid "Load Game"
+msgstr "Spel Laden"
+
+#: ../../../src/GameStateLoad.cpp:415
+msgid "Entering game world..."
+msgstr "Betreden spelwereld..."
+
+#: ../../../src/GameStateLoad.cpp:417
+msgid "Loading saved game..."
+msgstr "Laden opgeslagen spel..."
+
+#: ../../../src/GameStateLoad.cpp:438
+#, c-format
+msgid "Level %d %s"
+msgstr "Niveau %d %s"
+
+#: ../../../src/GameStateLoad.cpp:460
+msgid "Empty Slot"
+msgstr "Leeg Slot"
+
+#: ../../../src/GameStateNew.cpp:54
+msgid "Create Character"
+msgstr "Karakter Aanmaken"
+
+#: ../../../src/GameStateNew.cpp:78
+msgid "Choose a Portrait"
+msgstr "Kies een Portret"
+
+#: ../../../src/GameStateNew.cpp:80
+msgid "Choose a Name"
+msgstr "Kies een Naam"
+
+#: ../../../src/GameStateNew.cpp:83
+msgid "Permadeath?"
+msgstr "Permanente dood?"
+
+#: ../../../src/GameStatePlay.cpp:173
+msgid "Inventory is full."
+msgstr "Voorraad is vol."
+
+#: ../../../src/GameStateTitle.cpp:40
+msgid "Play Game"
+msgstr "Spel Spelen"
+
+#: ../../../src/GameStateTitle.cpp:45
+msgid "Configuration"
+msgstr "Instellingen"
+
+#: ../../../src/GameStateTitle.cpp:50
+msgid "Exit Game"
+msgstr "Spel Stoppen"
+
+#: ../../../src/GameStateTitle.cpp:57
+msgid "Flare Alpha v0.16"
+msgstr "Flare Alpha v0.16"
+
+#: ../../../src/ItemManager.cpp:355
+#, c-format
+msgid "Level %d"
+msgstr "Niveau %d"
+
+#: ../../../src/ItemManager.cpp:361 ../../../src/MenuInventory.cpp:124
+msgid "Main Hand"
+msgstr "Wapenhand"
+
+#: ../../../src/ItemManager.cpp:363 ../../../src/MenuInventory.cpp:126
+msgid "Body"
+msgstr "Lichaam"
+
+#: ../../../src/ItemManager.cpp:365 ../../../src/MenuInventory.cpp:128
+msgid "Off Hand"
+msgstr "Schildhand"
+
+#: ../../../src/ItemManager.cpp:367 ../../../src/MenuInventory.cpp:130
+msgid "Artifact"
+msgstr "Artefact"
+
+#: ../../../src/ItemManager.cpp:369
+msgid "Consumable"
+msgstr "Verbruiksartikel"
+
+#: ../../../src/ItemManager.cpp:371
+msgid "Gem"
+msgstr "Edelsteen"
+
+#: ../../../src/ItemManager.cpp:373
+msgid "Quest Item"
+msgstr "Opdracht gerelateerd artikel"
+
+#: ../../../src/ItemManager.cpp:380
+#, c-format
+msgid "Melee damage: %d-%d"
+msgstr "Mêleeschade: %d-%d"
+
+#: ../../../src/ItemManager.cpp:382
+#, c-format
+msgid "Melee damage: %d"
+msgstr "Mêleeschade: %d"
+
+#: ../../../src/ItemManager.cpp:386
+#, c-format
+msgid "Mental damage: %d-%d"
+msgstr "Mentale schade: %d-%d"
+
+#: ../../../src/ItemManager.cpp:388
+#, c-format
+msgid "Mental damage: %d"
+msgstr "Mentale schade: %d"
+
+#: ../../../src/ItemManager.cpp:392
+#, c-format
+msgid "Ranged damage: %d-%d"
+msgstr "Bereiksschade: %d-%d"
+
+#: ../../../src/ItemManager.cpp:394
+#, c-format
+msgid "Ranged damage: %d"
+msgstr "Bereiksschade: %d"
+
+#: ../../../src/ItemManager.cpp:401
+#, c-format
+msgid "Absorb: %d-%d"
+msgstr "Absorbtie: %d-%d"
+
+#: ../../../src/ItemManager.cpp:403
+#, c-format
+msgid "Absorb: %d"
+msgstr "Absorbtie: %d"
+
+#: ../../../src/ItemManager.cpp:411
+#, c-format
+msgid "Increases %s by %d"
+msgstr "Verhoogd %s met %d"
+
+#: ../../../src/ItemManager.cpp:415
+#, c-format
+msgid "Decreases %s by %d"
+msgstr "Verlaagd %s met %d"
+
+#: ../../../src/ItemManager.cpp:433 ../../../src/MenuCharacter.cpp:324
+#: ../../../src/MenuCharacter.cpp:330 ../../../src/MenuCharacter.cpp:336
+#: ../../../src/MenuCharacter.cpp:342
+#, c-format
+msgid "Requires Physical %d"
+msgstr "Vereist %d Fysiek"
+
+#: ../../../src/ItemManager.cpp:437 ../../../src/MenuCharacter.cpp:348
+#: ../../../src/MenuCharacter.cpp:354 ../../../src/MenuCharacter.cpp:360
+#: ../../../src/MenuCharacter.cpp:366
+#, c-format
+msgid "Requires Mental %d"
+msgstr "Vereist %d Mentaal"
+
+#: ../../../src/ItemManager.cpp:441 ../../../src/MenuCharacter.cpp:372
+#: ../../../src/MenuCharacter.cpp:378 ../../../src/MenuCharacter.cpp:384
+#: ../../../src/MenuCharacter.cpp:390
+#, c-format
+msgid "Requires Offense %d"
+msgstr "Vereist %d Aanval"
+
+#: ../../../src/ItemManager.cpp:445 ../../../src/MenuCharacter.cpp:396
+#: ../../../src/MenuCharacter.cpp:402 ../../../src/MenuCharacter.cpp:408
+#: ../../../src/MenuCharacter.cpp:414
+#, c-format
+msgid "Requires Defense %d"
+msgstr "Vereist %d Verdediging"
+
+#: ../../../src/ItemManager.cpp:455
+#, c-format
+msgid "Buy Price: %d gold"
+msgstr "Aankoopprijs: %d goud"
+
+#: ../../../src/ItemManager.cpp:457
+#, c-format
+msgid "Buy Price: %d gold each"
+msgstr "Aankoopprijs: %d goud per stuk"
+
+#: ../../../src/ItemManager.cpp:467
+#, c-format
+msgid "Sell Price: %d gold"
+msgstr "Verkoopprijs: %d goud"
+
+#: ../../../src/ItemManager.cpp:469
+#, c-format
+msgid "Sell Price: %d gold each"
+msgstr "Verkoopprijs: %d goud per stuk"
+
+#: ../../../src/LootManager.cpp:240 ../../../src/MenuInventory.cpp:132
+#, c-format
+msgid "%d Gold"
+msgstr "%d Goud"
+
+#: ../../../src/main.cpp:119
+msgid "Flare"
+msgstr "Flare"
+
+#: ../../../src/MapIso.cpp:917
+msgid "Unknown destination"
+msgstr "Onbekende bestemming"
+
+#: ../../../src/MenuActionBar.cpp:304
+msgid "Character Menu (C)"
+msgstr "Karakter Menu (C)"
+
+#: ../../../src/MenuActionBar.cpp:308
+msgid "Inventory Menu (I)"
+msgstr "Voorraad Menu (I)"
+
+#: ../../../src/MenuActionBar.cpp:312
+msgid "Power Menu (P)"
+msgstr "Vaardigheden Menu (P)"
+
+#: ../../../src/MenuActionBar.cpp:316
+msgid "Log Menu (L)"
+msgstr "Log Menu (L)"
+
+#: ../../../src/MenuCharacter.cpp:51
+msgid "Character"
+msgstr "Karakter"
+
+#: ../../../src/MenuCharacter.cpp:66
+msgid "Name"
+msgstr "Naam"
+
+#: ../../../src/MenuCharacter.cpp:67
+msgid "Level"
+msgstr "Niveau"
+
+#: ../../../src/MenuCharacter.cpp:68 ../../../src/MenuPowers.cpp:58
+#: ../../../src/MenuPowers.cpp:59
+msgid "Physical"
+msgstr "Fysiek"
+
+#: ../../../src/MenuCharacter.cpp:69 ../../../src/MenuPowers.cpp:60
+#: ../../../src/MenuPowers.cpp:61
+msgid "Mental"
+msgstr "Mentaal"
+
+#: ../../../src/MenuCharacter.cpp:70 ../../../src/MenuPowers.cpp:62
+#: ../../../src/MenuPowers.cpp:63
+msgid "Offense"
+msgstr "Aanval"
+
+#: ../../../src/MenuCharacter.cpp:71 ../../../src/MenuPowers.cpp:64
+#: ../../../src/MenuPowers.cpp:65
+msgid "Defense"
+msgstr "Verdediging"
+
+#: ../../../src/MenuCharacter.cpp:72
+msgid "Total HP"
+msgstr "Totale TP"
+
+#: ../../../src/MenuCharacter.cpp:73 ../../../src/MenuCharacter.cpp:75
+msgid "Regen"
+msgstr "Herstel"
+
+#: ../../../src/MenuCharacter.cpp:74
+msgid "Total MP"
+msgstr "Totale MP"
+
+#: ../../../src/MenuCharacter.cpp:76
+msgid "Accuracy vs. Def 1"
+msgstr "Nwkeurigh tov. Verdg 1"
+
+#: ../../../src/MenuCharacter.cpp:77
+msgid "vs. Def 5"
+msgstr "tov. Verdg 5"
+
+#: ../../../src/MenuCharacter.cpp:78
+msgid "Avoidance vs. Off 1"
+msgstr "Ontweiking. tov. Aanv 1"
+
+#: ../../../src/MenuCharacter.cpp:79
+msgid "vs. Off 5"
+msgstr "tov. Aanv 5"
+
+#: ../../../src/MenuCharacter.cpp:80
+msgid "Main Weapon"
+msgstr "Hoofdwapen"
+
+#: ../../../src/MenuCharacter.cpp:81
+msgid "Ranged Weapon"
+msgstr "Bereikswapen"
+
+#: ../../../src/MenuCharacter.cpp:82
+msgid "Crit Chance"
+msgstr "Fataal Kans"
+
+#: ../../../src/MenuCharacter.cpp:83
+msgid "Absorb"
+msgstr "Absorbtie"
+
+#: ../../../src/MenuCharacter.cpp:84
+msgid "Fire Resist"
+msgstr "Vuurweerstand"
+
+#: ../../../src/MenuCharacter.cpp:85
+msgid "Ice Resist"
+msgstr "IJsweerstand"
+
+#: ../../../src/MenuCharacter.cpp:251
+msgid "points remaining"
+msgstr "Punten resterend"
+
+#: ../../../src/MenuCharacter.cpp:261 ../../../src/MenuExperience.cpp:127
+#, c-format
+msgid "XP: %d"
+msgstr "EP: %d"
+
+#: ../../../src/MenuCharacter.cpp:263
+#, c-format
+msgid "Next: %d"
+msgstr "Volgende: %d"
+
+#: ../../../src/MenuCharacter.cpp:267
+msgid "Physical (P) increases melee weapon proficiency and total HP."
+msgstr "Fysiek (P) verhoogd beheersing van mêlee wapens en maximale TP."
+
+#: ../../../src/MenuCharacter.cpp:268 ../../../src/MenuCharacter.cpp:272
+#: ../../../src/MenuCharacter.cpp:276 ../../../src/MenuCharacter.cpp:280
+#, c-format
+msgid "base (%d), bonus (%d)"
+msgstr "basis (%d), bonus (%d)"
+
+#: ../../../src/MenuCharacter.cpp:271
+msgid "Mental (M) increases mental weapon proficiency and total MP."
+msgstr "Mentaal (M) verhoogd beheersing van mentale wapens en maximale MP"
+
+#: ../../../src/MenuCharacter.cpp:275
+msgid "Offense (O) increases ranged weapon proficiency and accuracy."
+msgstr "Aanval (A) verhoogd beheersing van bereikswapens en nauwkeurigheid."
+
+#: ../../../src/MenuCharacter.cpp:279
+msgid "Defense (D) increases armor proficiency and avoidance."
+msgstr "Verdediging (V) verhoogd beheersing van wapenuitrusting en ontwijken."
+
+#: ../../../src/MenuCharacter.cpp:283
+msgid "Each point of Physical grants +8 HP"
+msgstr "Ieder punt Fysiek verhoogd TP met 8"
+
+#: ../../../src/MenuCharacter.cpp:284
+msgid "Each level grants +2 HP"
+msgstr "Ieder niveau verhoogd TP met 2"
+
+#: ../../../src/MenuCharacter.cpp:287
+msgid "Ticks of HP regen per minute"
+msgstr "Herstel van TP per minuut"
+
+#: ../../../src/MenuCharacter.cpp:288
+msgid "Each point of Physical grants +4 HP regen"
+msgstr "Ieder punt Fysiek verhoogd TP herstel met 4"
+
+#: ../../../src/MenuCharacter.cpp:289
+msgid "Each level grants +1 HP regen"
+msgstr "Ieder niveau verhoogd TP herstel met 1"
+
+#: ../../../src/MenuCharacter.cpp:292
+msgid "Each point of Mental grants +8 MP"
+msgstr "Ieder punt Mentaal verhoogd MP met 8"
+
+#: ../../../src/MenuCharacter.cpp:293
+msgid "Each level grants +2 MP"
+msgstr "Ieder niveau verhoogd MP met 2"
+
+#: ../../../src/MenuCharacter.cpp:296
+msgid "Ticks of MP regen per minute"
+msgstr "MP herstel per minuut"
+
+#: ../../../src/MenuCharacter.cpp:297
+msgid "Each point of Mental grants +4 MP regen"
+msgstr "Ieder punt mentaal verhoogd MP-herstel met 4"
+
+#: ../../../src/MenuCharacter.cpp:298
+msgid "Each level grants +1 MP regen"
+msgstr "Ieder niveau verhoogd MP herstel met 1"
+
+#: ../../../src/MenuCharacter.cpp:301 ../../../src/MenuCharacter.cpp:305
+msgid "Each point of Offense grants +5 accuracy"
+msgstr "Ieder punt Aanval verhoogd nauwkeurigheid met 5"
+
+#: ../../../src/MenuCharacter.cpp:302 ../../../src/MenuCharacter.cpp:306
+msgid "Each level grants +1 accuracy"
+msgstr "Ieder niveai verhoogd nauwkeurigheid met 1"
+
+#: ../../../src/MenuCharacter.cpp:309 ../../../src/MenuCharacter.cpp:313
+msgid "Each point of Defense grants +5 avoidance"
+msgstr "Ieder punt Verdediging verhoogd ontwijken met 5"
+
+#: ../../../src/MenuCharacter.cpp:310 ../../../src/MenuCharacter.cpp:314
+msgid "Each level grants +1 avoidance"
+msgstr "Ieder niveau verhoogd ontwijken met 1"
+
+#: ../../../src/MenuCharacter.cpp:317
+msgid "Unspent attribute points"
+msgstr "Ongebruikte eigenschapspunten"
+
+#: ../../../src/MenuCharacter.cpp:321
+msgid "Dagger Proficiency"
+msgstr "Bekwaamheid: Dolk"
+
+#: ../../../src/MenuCharacter.cpp:327
+msgid "Shortsword Proficiency"
+msgstr "Bekwaamheid: Kort Zwaard"
+
+#: ../../../src/MenuCharacter.cpp:333
+msgid "Longsword Proficiency"
+msgstr "Bekwaamheid: Lang Zwaard"
+
+#: ../../../src/MenuCharacter.cpp:339
+msgid "Greatsword Proficiency"
+msgstr "Bekwaamheid: Grootzwaard"
+
+#: ../../../src/MenuCharacter.cpp:345
+msgid "Wand Proficiency"
+msgstr "Bekwaamheid: Toverstok"
+
+#: ../../../src/MenuCharacter.cpp:351
+msgid "Rod Proficiency"
+msgstr "Bekwaamheid: Staaf"
+
+#: ../../../src/MenuCharacter.cpp:357
+msgid "Staff Proficiency"
+msgstr "Bekwaamheid: Staf"
+
+#: ../../../src/MenuCharacter.cpp:363
+msgid "Greatstaff Proficiency"
+msgstr "Bekwaamheid: Grootstaf"
+
+#: ../../../src/MenuCharacter.cpp:369
+msgid "Slingshot Proficiency"
+msgstr "Bekwaamheid: Katapult"
+
+#: ../../../src/MenuCharacter.cpp:375
+msgid "Shortbow Proficiency"
+msgstr "Bekwaamheid: Korte Boog"
+
+#: ../../../src/MenuCharacter.cpp:381
+msgid "Longbow Proficiency"
+msgstr "Bekwaamheid: Lange boog"
+
+#: ../../../src/MenuCharacter.cpp:387
+msgid "Greatbow Proficiency"
+msgstr "Bekwaamheid: Grote Boog"
+
+#: ../../../src/MenuCharacter.cpp:393
+msgid "Light Armor Proficiency"
+msgstr "Bekwaamheid: Lichte Wapenuitrusting"
+
+#: ../../../src/MenuCharacter.cpp:399
+msgid "Light Shield Proficiency"
+msgstr "Bekwaamheid: Licht schild"
+
+#: ../../../src/MenuCharacter.cpp:405
+msgid "Heavy Armor Proficiency"
+msgstr "Bekwaamheid: Zware Wapenuitrusting"
+
+#: ../../../src/MenuCharacter.cpp:411
+msgid "Heavy Shield Proficiency"
+msgstr "Bekwaamheid: Zwaar Schild"
+
+#: ../../../src/MenuEnemy.cpp:108
+msgid "Dead"
+msgstr "Dood"
+
+#: ../../../src/MenuEnemy.cpp:112
+#, c-format
+msgid "%s level %d"
+msgstr "%s niveau %d"
+
+#: ../../../src/MenuExit.cpp:36
+msgid "Exit"
+msgstr "Stoppen"
+
+#: ../../../src/MenuExit.cpp:45
+msgid "Save and exit to title?"
+msgstr "Opslaan en naar het hoofdmenu"
+
+#: ../../../src/MenuExperience.cpp:124
+#, c-format
+msgid "XP: %d/%d"
+msgstr "EP: %d/%d"
+
+#: ../../../src/MenuInventory.cpp:122
+msgid "Inventory"
+msgstr "Voorraad"
+
+#: ../../../src/MenuInventory.cpp:163
+msgid "Use SHIFT to move only one item."
+msgstr "Houd SHIFT ingedrukt, om slechts één artikel te verplaatsen."
+
+#: ../../../src/MenuInventory.cpp:164
+msgid "CTRL-click a carried item to sell it."
+msgstr "Houd CTRL ingedrukt en klik op een artikel om het te verkopen."
+
+#: ../../../src/MenuInventory.cpp:327
+msgid "This item can only be used from the action bar."
+msgstr "Dit artikel kan alleen vanaf de actiebalk gebruikt worden."
+
+#: ../../../src/MenuLog.cpp:54
+msgid "Messages"
+msgstr "Berichten"
+
+#: ../../../src/MenuLog.cpp:55
+msgid "Quests"
+msgstr "Opdrachten"
+
+#: ../../../src/MenuLog.cpp:56
+msgid "Statistics"
+msgstr "Statistieken"
+
+#: ../../../src/MenuLog.cpp:125
+msgid "Log"
+msgstr "Log"
+
+#: ../../../src/MenuPowers.cpp:57
+msgid "Powers"
+msgstr "Vaardigheden"
+
+#: ../../../src/MenuPowers.cpp:253
+msgid "Physical + Offense grants melee and ranged attacks"
+msgstr "Fysiek + Aanval geeft mêlee- en bereiksaanvallen."
+
+#: ../../../src/MenuPowers.cpp:257
+msgid "Physical + Defense grants melee protection"
+msgstr "Fysiek + Verdediging geeft mêlee bescherming"
+
+#: ../../../src/MenuPowers.cpp:261
+msgid "Mental + Offense grants elemental spell attacks"
+msgstr "Mentaal + Aanval geeft aanvallende element magie"
+
+#: ../../../src/MenuPowers.cpp:265
+msgid "Mental + Defense grants healing and magical protection"
+msgstr "Mentaal + Verdediging geeft genezen en magische bescherming"
+
+#: ../../../src/MenuPowers.cpp:276
+msgid "Requires a physical weapon"
+msgstr "Vereist een fysiek wapen"
+
+#: ../../../src/MenuPowers.cpp:278
+msgid "Requires a mental weapon"
+msgstr "Vereist een mentaal wapen"
+
+#: ../../../src/MenuPowers.cpp:280
+msgid "Requires an offense weapon"
+msgstr "Vereist een aanvallend wapen"
+
+#: ../../../src/MenuPowers.cpp:291
+#, c-format
+msgid "Requires Physical Offense %d"
+msgstr "Vereist %d Fysieke Aanval"
+
+#: ../../../src/MenuPowers.cpp:292
+#, c-format
+msgid "Requires Physical Defense %d"
+msgstr "Vereist %d Fysieke Verdediging"
+
+#: ../../../src/MenuPowers.cpp:293
+#, c-format
+msgid "Requires Mental Offense %d"
+msgstr "Vereist %d Mentale Aanval"
+
+#: ../../../src/MenuPowers.cpp:294
+#, c-format
+msgid "Requires Mental Defense %d"
+msgstr "Vereist %d Mentale Verdediging"
+
+#: ../../../src/MenuPowers.cpp:300
+#, c-format
+msgid "Costs %d MP"
+msgstr "Kost %d MP"
+
+#: ../../../src/MenuPowers.cpp:304
+#, c-format
+msgid "Cooldown: %d seconds"
+msgstr "Afkoeltijd: %d seconden"
+
+#: ../../../src/MenuTalker.cpp:50
+msgid "Trade"
+msgstr "Handelen"
+
+#: ../../../src/MenuVendor.cpp:99
+msgid "Vendor"
+msgstr "Verkoper"
+
+#: ../../../src/StatBlock.cpp:351
+msgid "Grand Master"
+msgstr "Grootmeester"
+
+#: ../../../src/StatBlock.cpp:354
+msgid "Master"
+msgstr "Meester"
+
+#: ../../../src/StatBlock.cpp:357
+msgid "Warrior"
+msgstr "Strijder"
+
+#: ../../../src/StatBlock.cpp:359
+msgid "Wizard"
+msgstr "Magiër"
+
+#: ../../../src/StatBlock.cpp:361
+msgid "Ranger"
+msgstr "Woudloper"
+
+#: ../../../src/StatBlock.cpp:363
+msgid "Paladin"
+msgstr "Paladin"
+
+#: ../../../src/StatBlock.cpp:366
+msgid "Rogue"
+msgstr "Schurk"
+
+#: ../../../src/StatBlock.cpp:368
+msgid "Knight"
+msgstr "Ridder"
+
+#: ../../../src/StatBlock.cpp:370
+msgid "Shaman"
+msgstr "Sjaman"
+
+#: ../../../src/StatBlock.cpp:372
+msgid "Cleric"
+msgstr "Priester"
+
+#: ../../../src/StatBlock.cpp:374
+msgid "Battle Mage"
+msgstr "Strijdmagiër"
+
+#: ../../../src/StatBlock.cpp:376
+msgid "Heavy Archer"
+msgstr "Scherpschutter"
+
+#: ../../../src/StatBlock.cpp:378
+msgid "Adventurer"
+msgstr "Avonturier"


### PR DESCRIPTION
Added and play tested engine.nl.po. Seems to work for the strings that are in engine.pot.

Since not all strings on e.g. the configuration screen are in engine.pot, some text on the screen will be in English.

I am guessing we either just need an updated engine.pot, or the code needs additional gettext(?) calls and we can subsequently generate(?) an updated engine.po.

I welcome recommendations on how to proceed with that. :-)
