### PR TITLE
Put elemental resist strings in config file

### DIFF
--- a/mods/fantasycore/engine/elements.txt
+++ b/mods/fantasycore/engine/elements.txt
@@ -1,7 +1,25 @@
 # this elemental list covers the western 4, eastern 5, and classic rpg light vs. shadow
-fire
-ice
-earth
-wind
-shadow
-light
+
+[element]
+name=fire
+resist=Fire Resistance
+
+[element]
+name=ice
+resist=Ice Resistance
+
+[element]
+name=earth
+resist=Earth Resistance
+
+[element]
+name=wind
+resist=Wind Resistance
+
+[element]
+name=shadow
+resist=Shadow Resistance
+
+[element]
+name=light
+resist=Light Resistance

--- a/mods/fantasycore/languages/xgettext.py
+++ b/mods/fantasycore/languages/xgettext.py
@@ -29,7 +29,7 @@ def extract(filename):
     if os.path.exists(filename):
         infile = open(filename, 'r')
         triggers = ['msg', 'him', 'her', 'you', 'name', 'title', 'tooltip',
-                'power_desc', 'quest_text', 'description', 'item_type', 'slot_name', 'tab_title']
+                'power_desc', 'quest_text', 'description', 'item_type', 'slot_name', 'tab_title', 'resist']
         for i,line in enumerate(infile):
             for trigger in triggers:
                 if line.startswith(trigger + '='):
@@ -87,6 +87,7 @@ extract('../items/items.txt')
 extract('../menus/inventory.txt')
 extract('../menus/powers.txt')
 extract('../powers/powers.txt')
+extract('../engine/elements.txt')
 
 if os.path.exists('../enemies'):
 	for filename in os.listdir('../enemies'):

--- a/mods/minicore/engine/elements.txt
+++ b/mods/minicore/engine/elements.txt
@@ -1,7 +1,25 @@
 # this elemental list covers the western 4, eastern 5, and classic rpg light vs. shadow
-fire
-ice
-earth
-wind
-shadow
-light
+
+[element]
+name=fire
+resist=Fire Resistance
+
+[element]
+name=ice
+resist=Ice Resistance
+
+[element]
+name=earth
+resist=Earth Resistance
+
+[element]
+name=wind
+resist=Wind Resistance
+
+[element]
+name=shadow
+resist=Shadow Resistance
+
+[element]
+name=light
+resist=Light Resistance

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -391,9 +391,7 @@ void MenuCharacter::refreshStats() {
 	if (show_stat[13]) {
 		for (unsigned int j=0; j<stats->vulnerable.size(); j++) {
 			ss.str("");
-			std::string element = ELEMENTS[j];
-			element[0] = toupper((unsigned char)element[0]);
-			ss << msg->get(element+" Resistance:") << " " << (100 - stats->vulnerable[j]) << "%";
+			ss << ELEMENTS[j].resist << ": " << (100 - stats->vulnerable[j]) << "%";
 			statList->append(ss.str(),"");
 		}
 	}

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -766,7 +766,7 @@ void MenuInventory::applyEquipment(ItemStack *equipped) {
 			}
 
 			for (unsigned int j=0; j<ELEMENTS.size(); j++) {
-				if (item.bonus_stat[bonus_counter] == ELEMENTS[j] + " resist")
+				if (item.bonus_stat[bonus_counter] == ELEMENTS[j].name + " resist")
 					stats->vulnerable[j] -= item.bonus_val[bonus_counter];
 			}
 

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -248,7 +248,7 @@ void PowerManager::loadPowers(const std::string& filename) {
 			}
 			else if (infile.key == "trait_elemental") {
 				for (unsigned int i=0; i<ELEMENTS.size(); i++) {
-					if (infile.val == ELEMENTS[i]) powers[input_id].trait_elemental = i;
+					if (infile.val == ELEMENTS[i].name) powers[input_id].trait_elemental = i;
 				}
 			}
 			else if (infile.key == "forced_move") {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -138,7 +138,7 @@ short MAX_BLOCK = 100;
 short MAX_AVOIDANCE = 99;
 
 // Elemental types
-std::vector<std::string> ELEMENTS;
+std::vector<Element> ELEMENTS;
 
 // Other Settings
 bool MENUS_PAUSE = false;
@@ -417,24 +417,19 @@ void loadMiscSettings() {
 		fprintf(stderr, "No combat engine settings config found!\n");
 	}
 	// elements.txt
-	ifstream infiles;
-	std::string line, starts_with;
-	infiles.open(mods->locate("engine/elements.txt").c_str(), ios::in);
-	ELEMENTS.clear();
-	if (infiles.is_open()){
-		while (!infiles.eof()) {
-			line = getLine(infiles);
-
-			// skip ahead if this line is empty
-			if (line.length() == 0) continue;
-
-			// skip comments
-			starts_with = line.at(0);
-			if (starts_with == "#") continue;
-
-			ELEMENTS.push_back(line);
+	if (infile.open(mods->locate("engine/elements.txt").c_str())) {
+		Element e;
+		ELEMENTS.clear();
+		while (infile.next()) {
+			if (infile.new_section) {
+				if (infile.section == "element" && e.name != "") {
+					ELEMENTS.push_back(e);
+				}
+			}
+			if (infile.key == "name") e.name = msg->get(infile.val);
+			else if (infile.key == "resist") e.resist = msg->get(infile.val);
 		}
-		infiles.close();
+		infile.close();
 	}
 	else {
 		fprintf(stderr, "No elemental settings config found!\n");

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -25,6 +25,11 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <string>
 #include <vector>
 
+typedef struct Element{
+	std::string name;
+	std::string resist;
+}Element;
+
 // Path info
 extern std::string PATH_CONF; // user-configurable settings files
 extern std::string PATH_USER; // important per-user data (saves)
@@ -101,7 +106,7 @@ extern short MAX_BLOCK;
 extern short MAX_AVOIDANCE;
 
 // Elemental types
-extern std::vector<std::string> ELEMENTS;
+extern std::vector<Element> ELEMENTS;
 
 void setPaths();
 void loadTilesetSettings();

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -355,7 +355,7 @@ void StatBlock::load(const string& filename) {
 			else if (infile.key == "suppress_hp") suppress_hp = num;
 
 			for (unsigned int i=0; i<ELEMENTS.size(); i++) {
-				if (infile.key == "vulnerable_" + ELEMENTS[i]) vulnerable[i] = num;
+				if (infile.key == "vulnerable_" + ELEMENTS[i].name) vulnerable[i] = num;
 			}
 		}
 		infile.close();


### PR DESCRIPTION
xgettext.py should be able to grab those strings now.

Since we're most likely going to be doing something similar with item types, I figured this should be changed as well.
