### PR TITLE
Don't use hardcoded slot indexes in LoadPreview

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -93,10 +93,7 @@ void Avatar::init() {
 
 	haz = NULL;
 
-	// TODO hardcoded
-	for (int i=0; i<4; i++) {
-		img_gfx.push_back("");
-	}
+	img_gfx.resize(4,"");
 	body = -1;
 
 	transform_triggered = false;
@@ -153,6 +150,8 @@ void Avatar::loadGraphics(std::vector<Layer_gfx> _img_gfx) {
 	vector<SDL_Surface*> gfx_surf;
 	SDL_Rect src;
 	SDL_Rect dest;
+
+	if (img_gfx.size() < _img_gfx.size()) img_gfx.resize(_img_gfx.size(), "");
 
 	// Default appearance
 	// Find body gfx index

--- a/src/GameStateLoad.h
+++ b/src/GameStateLoad.h
@@ -67,7 +67,8 @@ private:
 	SDL_Surface *portrait;
 	SDL_Surface *sprites[GAME_SLOT_MAX];
 	StatBlock stats[GAME_SLOT_MAX];
-	int equipped[GAME_SLOT_MAX][3];	
+	std::vector<int> equipped[GAME_SLOT_MAX];
+	std::vector<std::string> preview_layer;
 	SDL_Rect slot_pos[GAME_SLOT_MAX];
 	std::string current_map[GAME_SLOT_MAX];
 


### PR DESCRIPTION
Don't use hardcoded slot indexes in LoadPreview. Also fixed img_gfx size in Avatar.cpp
