### PR TITLE
Don't store MUSIC_VOLUME and SOUND_VOLUME as char

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -112,8 +112,8 @@ bool TEXTURE_QUALITY;
 bool ANIMATED_TILES;
 
 // Audio Settings
-unsigned char MUSIC_VOLUME;
-unsigned char SOUND_VOLUME;
+unsigned short MUSIC_VOLUME;
+unsigned short SOUND_VOLUME;
 
 // User Preferences
 bool COMBAT_TEXT;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -47,8 +47,8 @@ extern unsigned short ICON_SIZE_SMALL;
 extern unsigned short ICON_SIZE_LARGE;
 
 // Audio and Video Settings
-extern unsigned char MUSIC_VOLUME;
-extern unsigned char SOUND_VOLUME;
+extern unsigned short MUSIC_VOLUME;
+extern unsigned short SOUND_VOLUME;
 extern bool FULLSCREEN;
 extern unsigned char BITS_PER_PIXEL;
 extern unsigned short FRAMES_PER_SEC;


### PR DESCRIPTION
Otherwise, the output to the user's settings.txt doesn't make sense (my volumes read as: `^@`).
