### PR TITLE
Put formatted item types in items/types.txt

### DIFF
--- a/mods/fantasycore/items/types.txt
+++ b/mods/fantasycore/items/types.txt
@@ -1,0 +1,32 @@
+[type]
+name=artifact
+description=Artifact
+
+[type]
+name=body
+description=Body
+
+[type]
+name=consumable
+description=Consumable
+
+[type]
+name=gem
+description=Gem
+
+[type]
+name=main
+description=Main Hand
+
+[type]
+name=off
+description=Off Hand
+
+[type]
+name=quest
+description=Quest Item
+
+[type]
+name=ring
+description=Ring
+

--- a/mods/fantasycore/languages/xgettext.py
+++ b/mods/fantasycore/languages/xgettext.py
@@ -84,6 +84,7 @@ def get_quests():
 
 # HERE'S THE MAIN EXECUTION
 extract('../items/items.txt')
+extract('../items/types.txt')
 extract('../menus/inventory.txt')
 extract('../menus/powers.txt')
 extract('../powers/powers.txt')

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -66,6 +66,12 @@ void ItemManager::loadAll() {
 		if (fileExists(test_path)) {
 			this->load(test_path);
 		}
+
+		test_path = PATH_DATA + "mods/" + mods->mod_list[i] + "/items/types.txt";
+
+		if (fileExists(test_path)) {
+			this->loadTypes(test_path);
+		}
 	}
 	shrinkItems();
 }
@@ -231,6 +237,34 @@ void ItemManager::load(const string& filename) {
 	}
 }
 
+void ItemManager::loadTypes(const string& filename) {
+	FileParser infile;
+	string type,description;
+	type = description = "";
+
+	if (infile.open(filename)) {
+		while (infile.next()) {
+			if (infile.key == "name") type = infile.val;
+			else if (infile.key == "description") description = infile.val;
+
+			if (type != "" && description != "") {
+				item_types[type] = description;
+				type = description = "";
+			}
+		}
+		infile.close();
+	}
+}
+
+string ItemManager::getItemType(std::string _type) {
+	map<string,string>::iterator it,end;
+	for (it=item_types.begin(), end=item_types.end(); it!=end; it++) {
+		if (_type.compare(it->first) == 0) return it->second;
+	}
+	// If all else fails, return the original string
+	return _type;
+}
+
 void ItemManager::loadSounds() {
 	memset(sfx, 0, sizeof(sfx));
 
@@ -393,14 +427,7 @@ TooltipData ItemManager::getTooltip(int item, StatBlock *stats, bool vendor_view
 
 	// type
 	if (items[item].type != "other") {
-		if (items[item].type == "main")
-			tip.lines[tip.num_lines++] = msg->get("main hand");
-		else if (items[item].type == "off")
-			tip.lines[tip.num_lines++] = msg->get("off hand");
-		else if (items[item].type == "quest")
-			tip.lines[tip.num_lines++] = msg->get("quest item");
-		else
-			tip.lines[tip.num_lines++] = msg->get(items[item].type);
+		tip.lines[tip.num_lines++] = msg->get(getItemType(items[item].type));
 	}
 
 	// damage

--- a/src/ItemManager.h
+++ b/src/ItemManager.h
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <SDL_image.h>
 #include <SDL_mixer.h>
 
+#include <map>
 #include <string>
 #include <stdint.h>
 #include <vector>
@@ -146,6 +147,7 @@ private:
 	Mix_Chunk *sfx[12];
 
 	void load(const std::string& filename);
+	void loadTypes(const std::string& filename);
 	void loadAll();
 	void loadSounds();
 	void loadIcons();
@@ -166,8 +168,10 @@ public:
 	void playCoinsSound();
 	TooltipData getTooltip(int item, StatBlock *stats, bool vendor_view);
 	TooltipData getShortTooltip(ItemStack item);
+	std::string getItemType(std::string _type);
 
 	std::vector<Item> items;
+	std::map<std::string,std::string> item_types;
 
 	std::vector<std::string> item_class_names; // a vector of all defined classes of items
 	// belongs to the item_class_names vector and contains a vector of item ids which belong to that specific class.


### PR DESCRIPTION
Should now work with xgettext.py. If a type isn't defined in types.txt, it will fall back to its internal name.
