### PR TITLE
Change the logic if a talker dialog should be shown or not depending

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
+Copyright © 2012 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -432,17 +433,18 @@ void GameStatePlay::checkNPCInteraction() {
 	// if close enough to the NPC, open the appropriate interaction screen
 	if (npc_click != -1 && interact_distance < max_interact_distance && pc->stats.alive && pc->stats.humanoid) {
 		inpt->lock[MAIN1] = true;
+		bool npc_have_dialog = !(npcs->npcs[npc_id]->chooseDialogNode() == NPC_NO_DIALOG_AVAIL);
 
-		if ((npcs->npcs[npc_id]->vendor && !npcs->npcs[npc_id]->talker)) {
+		if (npcs->npcs[npc_id]->vendor && !npc_have_dialog) {
 			menu->vendor->talker_visible = false;
 			menu->talker->vendor_visible = true;
 		}
-		else if (npcs->npcs[npc_id]->talker) {
+		else if (npcs->npcs[npc_id]->talker && npc_have_dialog) {
 			menu->vendor->talker_visible = true;
 			menu->talker->vendor_visible = false;
 
 			npcs->npcs[npc_id]->playSound(NPC_VOX_INTRO);
-        }
+		}
 	}
 
 	if (npc_id != -1 && interact_distance < max_interact_distance && pc->stats.alive && pc->stats.humanoid) {

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
+Copyright © 2012 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -277,6 +278,8 @@ bool NPC::playSound(int type, int id) {
  * Determine the correct dialog node by the place in the story line
  */
 int NPC::chooseDialogNode() {
+        if (!talker)
+                return NPC_NO_DIALOG_AVAIL;
 
 	// NPC dialog nodes are listed in timeline order
 	// So check from the bottom of the list up
@@ -302,7 +305,7 @@ int NPC::chooseDialogNode() {
 			}
 		}
 	}
-	return 0;
+	return NPC_NO_DIALOG_AVAIL;
 }
 
 

--- a/src/NPC.h
+++ b/src/NPC.h
@@ -38,6 +38,7 @@ class MapRenderer;
 const int NPC_VENDOR_MAX_STOCK = 80;
 const int NPC_VOX_INTRO = 0;
 const int NPC_VOX_QUEST = 1;
+const int NPC_NO_DIALOG_AVAIL = -1;
 
 class NPC : public Entity {
 protected:


### PR DESCRIPTION
on if NPC have anything to say or not, this is very neat if a NPC is both
vendor and talker, if he has nothing to say you get into shop without
a talker dialog.

This fixes a bug were the last dialog node 0 always is choosen to be
displayed (chooseDialogNode()) if no other dialogs matches. Also if
dialog index 0 have requires_not which evaluates false it will be
chown anyway.
