### PR TITLE
Add CombatText to potions and tweak some colors/text

### DIFF
--- a/mods/320x240/engine/font_colors.txt
+++ b/mods/320x240/engine/font_colors.txt
@@ -6,10 +6,11 @@ widget_normal=240,240,240
 widget_disabled=127,127,127
 
 # combat log
-combat_normal=255,255,255
-combat_crit=255,0,0
-combat_heal=0,255,0
-combat_shield=0,0,255
+combat_givedmg=255,255,255
+combat_takedmg=192,48,48
+combat_crit=255,215,0
+combat_buff=115,230,172
+combat_miss=128,128,128
 
 # tooltip lines
 requirements_not_met=255,0,0

--- a/mods/fantasycore/engine/font_colors.txt
+++ b/mods/fantasycore/engine/font_colors.txt
@@ -6,10 +6,11 @@ widget_normal=240,240,240
 widget_disabled=127,127,127
 
 # combat log
-combat_normal=255,255,255
+combat_givedmg=255,255,255
+combat_takedmg=192,48,48
 combat_crit=255,215,0
-combat_buff=0,255,0
-combat_miss=255,0,0
+combat_buff=115,230,172
+combat_miss=128,128,128
 
 # tooltip lines
 requirements_not_met=255,0,0

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -443,7 +443,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 	// check for bleeding spurt
 	if (stats.bleed_duration % 30 == 1) {
-		CombatText::Instance()->addMessage(1, stats.pos, COMBAT_MESSAGE_DAMAGE);
+		CombatText::Instance()->addMessage(1, stats.pos, COMBAT_MESSAGE_TAKEDMG);
 		powers->activate(POWER_SPARK_BLOOD, &stats, stats.pos);
 	}
 	// check for bleeding to death
@@ -749,7 +749,7 @@ bool Avatar::takeHit(Hazard h) {
 
 
 		int prev_hp = stats.hp;
-		combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_DAMAGE);
+		combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_TAKEDMG);
 		stats.takeDamage(dmg);
 
 		// after effects

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -81,7 +81,7 @@ void BehaviorStandard::doUpkeep() {
 
 	// TEMP: check for bleeding spurt
 	if (e->stats.bleed_duration % 30 == 1) {
-	    CombatText::Instance()->addMessage(1, e->stats.pos, COMBAT_MESSAGE_DAMAGE);
+	    CombatText::Instance()->addMessage(1, e->stats.pos, COMBAT_MESSAGE_GIVEDMG);
 		e->powers->activate(POWER_SPARK_BLOOD, &e->stats, e->stats.pos);
 	}
 

--- a/src/CombatText.cpp
+++ b/src/CombatText.cpp
@@ -33,7 +33,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <sstream>
 
 CombatText::CombatText() {
-	msg_color[COMBAT_MESSAGE_DAMAGE] = font->getColor("combat_damage");
+	msg_color[COMBAT_MESSAGE_GIVEDMG] = font->getColor("combat_givedmg");
+	msg_color[COMBAT_MESSAGE_TAKEDMG] = font->getColor("combat_takedmg");
 	msg_color[COMBAT_MESSAGE_CRIT] = font->getColor("combat_crit");
 	msg_color[COMBAT_MESSAGE_BUFF] = font->getColor("combat_buff");
 	msg_color[COMBAT_MESSAGE_MISS] = font->getColor("combat_miss");

--- a/src/CombatText.h
+++ b/src/CombatText.h
@@ -33,10 +33,11 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <vector>
 #include <string>
 
-#define COMBAT_MESSAGE_DAMAGE 0
-#define COMBAT_MESSAGE_CRIT 1
-#define COMBAT_MESSAGE_MISS 2
-#define COMBAT_MESSAGE_BUFF 3
+#define COMBAT_MESSAGE_GIVEDMG 0
+#define COMBAT_MESSAGE_TAKEDMG 1
+#define COMBAT_MESSAGE_CRIT 2
+#define COMBAT_MESSAGE_MISS 3
+#define COMBAT_MESSAGE_BUFF 4
 
 class WidgetLabel;
 
@@ -64,7 +65,7 @@ private:
 
     static CombatText* m_pInstance;
 
-	SDL_Color msg_color[4];
+	SDL_Color msg_color[5];
 	int duration;
 	int speed;
 };

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -203,7 +203,7 @@ bool Enemy::takeHit(Hazard h) {
 		}
 		else {
 		    // show normal damage
-		    combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_DAMAGE);
+		    combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_GIVEDMG);
 		}
 
 		// apply damage

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -769,27 +769,31 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 			heal_amt = rand() % (heal_max - heal_min) + heal_min;
 		else // avoid div by 0
 			heal_amt = heal_min;
-		CombatText::Instance()->addMessage(heal_amt, src_stats->pos, COMBAT_MESSAGE_BUFF);
+		CombatText::Instance()->addMessage(msg->get("+%d HP",heal_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
 		src_stats->hp += heal_amt;
 		if (src_stats->hp > src_stats->maxhp) src_stats->hp = src_stats->maxhp;
 	}
 
 	// hp restore
 	if (powers[power_index].buff_restore_hp > 0) {
-		src_stats->hp += powers[power_index].buff_restore_hp;
+		int hp_amt = powers[power_index].buff_restore_hp;
+		CombatText::Instance()->addMessage(msg->get("+%d HP",hp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
+		src_stats->hp += hp_amt;
 		if (src_stats->hp > src_stats->maxhp) src_stats->hp = src_stats->maxhp;
 	}
 
 	// mp restore
 	if (powers[power_index].buff_restore_mp > 0) {
-		src_stats->mp += powers[power_index].buff_restore_mp;
+		int mp_amt = powers[power_index].buff_restore_mp;
+		CombatText::Instance()->addMessage(msg->get("+%d MP",mp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
+		src_stats->mp += mp_amt;
 		if (src_stats->mp > src_stats->maxmp) src_stats->mp = src_stats->maxmp;
 	}
 
 	// charge shield to max ment weapon damage * damage multiplier
 	if (powers[power_index].buff_shield) {
 	    int shield_amt = (int)ceil(src_stats->dmg_ment_max * powers[power_index].damage_multiplier / 100.0) + (src_stats->get_mental()*src_stats->bonus_per_mental);
-	    CombatText::Instance()->addMessage(shield_amt, src_stats->pos, COMBAT_MESSAGE_BUFF);
+		CombatText::Instance()->addMessage(msg->get("+%d Shield",shield_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
 		src_stats->shield_hp = src_stats->shield_hp_total = shield_amt;
 	}
 


### PR DESCRIPTION
Closes #926

---

Along with the potions' text, I added some text to the buff messages for Heal and Shield. Since we use only one color for buffs, I think it's important that we distinguish what's being buffed.

Secondly, I changed some of the colors. The old buff color matched the Heal animation too much, so it looked odd when using Shield. I've opted for a more blue, less saturated, minty color here. I've also separated the damage colors for giving (white) and taking (red) damage. When all damage was white, it was hard to tell who's damage was who's. As a result, I've made the previously red "miss" text grey, which I think is a more common color to convey misses.
