### PR TITLE
Added initial version of GameTime object to keep track

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ Set (FLARE_SOURCES
 	./src/GameStatePlay.cpp
 	./src/GameStateNew.cpp
 	./src/GameSwitcher.cpp
+	./src/GameTime.cpp
 	./src/GetText.cpp
 	./src/Hazard.cpp
 	./src/HazardManager.cpp

--- a/src/GameTime.cpp
+++ b/src/GameTime.cpp
@@ -1,0 +1,156 @@
+/*
+Copyright © 2012 Henrik Andersson
+
+This file is part of FLARE.
+
+FLARE is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+FLARE is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+FLARE.  If not, see http://www.gnu.org/licenses/
+*/
+
+#include <sstream>
+#include <SDL.h>
+
+#include "GameTime.h"
+#include "Settings.h"
+#include "UtilsParsing.h"
+
+const int TIME_UPDATE_INTERVAL = 100;
+
+GameTime::GameTime() {
+        ticks = 0;
+}
+
+GameTime::~GameTime() {
+}
+
+void GameTime::update() {
+        unsigned int cticks = SDL_GetTicks();
+		if ((cticks - ticks) > TIME_UPDATE_INTERVAL) 
+		{
+		        real.addMs((cticks-ticks));
+				ingame.addMs((cticks-ticks) * TIME_FACTOR);
+				ticks = cticks;
+		}
+}
+
+void GameTime::reset() {
+        ticks = SDL_GetTicks();
+		ingame.reset();
+		real.reset();
+}
+
+Time::Time() {
+        reset();
+}
+
+Time::Time(std::string canonical) {
+        fromCanonicalString(canonical);
+}
+
+
+
+Time::~Time() {
+}
+
+/** \brief Initialize time from canonical string.
+    \note Canonincal time format is days:hours:minutes:seconds:ms
+*/
+void Time::fromCanonicalString(std::string canonical) {
+        int i = 0;
+		std::string s;
+		std::stringstream ss(canonical);
+		unsigned int v[5] = {0,0,0,0,0};
+		
+		while (getline(ss, s, ':')) {
+		  v[i] = toInt(s);
+		  i++;
+		}
+
+        fromVector(v);
+}
+
+/** \brief Get canonical string of time.
+*/
+std::string Time::toCanonicalString() {
+        std::stringstream ss("");
+		ss << days << ":" << hours << ":" << minutes << ":" << seconds << ":" << ms;
+		return ss.str();
+}
+
+/** \brief Set time from vector of time components.
+ */
+void Time::fromVector(unsigned int *v) {
+        days    = v[0];
+		hours   = v[1];  
+		minutes = v[2];
+		seconds = v[3];
+		ms      = v[4];
+}
+
+/** \brief Get display string representation of time object.
+	\param[in] [current] True for current time and False for duration. 
+*/
+std::string Time::toString(bool current) {
+        std::string tof;
+		std::stringstream ss("");
+
+		if (current) {
+		        if (hours >= 5 && hours < 12)        tof = "Morning";
+				else if (hours >= 12 && hours < 13)  tof = "Noon";
+				else if (hours >= 13 && hours < 18)  tof = "Afternoon";
+				else if (hours >= 18 && hours < 20)  tof = "Evening";
+				else if (hours >= 20 && hours < 24)  tof = "Night";
+				else if (hours >= 0 && hours < 1)    tof = "Midnight";
+				else if (hours >= 1 && hours < 5)    tof = "Late night";
+				ss << "Day " <<  days+1 << " - " << tof;
+		}
+		else
+		        ss << days << " days, " << hours << " hours and " << minutes << " minutes.";
+
+		return ss.str();
+}
+
+/** \brief Increase Time with milliseconds. 
+*/
+void Time::addMs(unsigned int millis) {
+        ms += millis;
+		unsigned int secs = (ms / 1000.0f);
+		if (secs > 0) {
+		        seconds += secs;
+				ms -= secs*1000;
+				recalculate();
+		}
+}
+
+/** \brief Recalculate time. 
+*/
+void Time::recalculate() {
+        if(seconds >= 60) {
+		        minutes += 1 + (seconds % 60);
+				seconds = 0;
+		}
+
+		if(minutes >= 60) {
+		        hours += 1 + (minutes % 60);
+				minutes = 0;
+		}
+
+		if(hours >= 24) {
+		        days += 1 + (hours % 24);
+				hours = 0;
+		}
+}
+
+/** \brief Reset time. 
+*/
+void Time::reset() {
+  days = hours = minutes = seconds = ms = 0;
+}

--- a/src/GameTime.h
+++ b/src/GameTime.h
@@ -1,0 +1,68 @@
+/*
+Copyright © 2012 Henrik Andersson
+
+This file is part of FLARE.
+
+FLARE is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+FLARE is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+FLARE.  If not, see http://www.gnu.org/licenses/
+*/
+
+/**
+ * class WorlTime
+ *
+ * Handles logic of game engine World Time and a Time helper class
+ *
+ */
+
+#include <string>
+
+#ifndef WORLDTIME_H
+#define WORLDTIME_H
+
+class Time {
+public:
+        Time();
+	Time(std::string canonical);
+	virtual ~Time();
+	void fromVector(unsigned int *v);
+	void fromCanonicalString(std::string canonical);
+	std::string toString(bool simplified=true);
+	std::string toCanonicalString();
+	void addMs(unsigned int ms);
+	void reset();
+
+protected:
+        int days;
+        int hours;
+        int minutes;
+	int seconds;
+	int ms;
+
+	void recalculate();
+  
+};
+
+class GameTime {
+public:
+        GameTime();
+        ~GameTime();
+	
+        void update();
+	void reset();
+	
+	Time ingame;
+	Time real;
+
+protected:
+	unsigned int ticks;
+};
+
+#endif

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,6 +1,7 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
 Copyright © 2012 Igor Paliychuk
+Copyright © 2012 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -150,7 +151,7 @@ bool MENUS_PAUSE = false;
 std::string DEFAULT_NAME = "";
 bool SAVE_HPMP = false;
 bool ENABLE_PLAYGAME = false;
-
+int TIME_FACTOR = 1;
 
 /**
  * Set system paths
@@ -370,6 +371,9 @@ void loadMiscSettings() {
 		while (infile.next()) {
 			if (infile.key == "enable_playgame") {
 				ENABLE_PLAYGAME = toInt(infile.val);
+			}
+			else if (infile.key == "time_factor") {
+			        TIME_FACTOR = toInt(infile.val);
 			}
 		}
 		infile.close();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -1,6 +1,7 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
 Copyright © 2012 Igor Paliychuk
+Copyright © 2012 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -22,7 +23,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #ifndef SETTINGS_H
 #define SETTINGS_H
-
+#include <ctime>
 #include <string>
 #include <vector>
 
@@ -79,6 +80,7 @@ extern bool MENUS_PAUSE;
 extern std::string DEFAULT_NAME;
 extern bool SAVE_HPMP;
 extern bool ENABLE_PLAYGAME;
+extern int TIME_FACTOR;
 
 // Tile Settings
 extern unsigned short UNITS_PER_TILE;


### PR DESCRIPTION
of in game times and time spent on playing the game.

In game times are scaled by time_factor so an actual day
in game is shorter then real day, eg. time_factor of 10
makes a 24hour period in game actual 2.4hours in game play.

Conflicts:

```
src/Settings.cpp
src/Settings.h
```
