### PR TITLE
Reposition combat text relative to map in some cases

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -448,7 +448,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 	// check for bleeding spurt
 	if (stats.bleed_duration % 30 == 1) {
-		CombatText::Instance()->addMessage(1, stats.pos, COMBAT_MESSAGE_TAKEDMG);
+		CombatText::Instance()->addMessage(1, stats.pos, COMBAT_MESSAGE_TAKEDMG, true);
 		powers->activate(POWER_SPARK_BLOOD, &stats, stats.pos);
 	}
 	// check for bleeding to death
@@ -697,7 +697,7 @@ bool Avatar::takeHit(Hazard h) {
 		if (stats.blocking) avoidance *= 2;
 		if (MAX_AVOIDANCE < avoidance) avoidance = MAX_AVOIDANCE;
 		if (rand() % 100 > (h.accuracy - avoidance + 25)) {
-			combat_text->addMessage("miss", stats.pos, COMBAT_MESSAGE_MISS);
+			combat_text->addMessage("miss", stats.pos, COMBAT_MESSAGE_MISS, true);
 			return false;
 		}
 
@@ -754,7 +754,7 @@ bool Avatar::takeHit(Hazard h) {
 
 
 		int prev_hp = stats.hp;
-		combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_TAKEDMG);
+		combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_TAKEDMG, true);
 		stats.takeDamage(dmg);
 
 		// after effects
@@ -772,7 +772,7 @@ bool Avatar::takeHit(Hazard h) {
 			if (h.hp_steal != 0) {
 				int steal_amt = (dmg * h.hp_steal) / 100;
 				if (steal_amt == 0 && dmg > 0) steal_amt = 1;
-				combat_text->addMessage(steal_amt, h.src_stats->pos, COMBAT_MESSAGE_BUFF);
+				combat_text->addMessage(steal_amt, h.src_stats->pos, COMBAT_MESSAGE_BUFF, false);
 				h.src_stats->hp = min(h.src_stats->hp + steal_amt, h.src_stats->maxhp);
 			}
 			// if (h.mp_steal != 0) { //enemies don't have MP

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -81,7 +81,7 @@ void BehaviorStandard::doUpkeep() {
 
 	// TEMP: check for bleeding spurt
 	if (e->stats.bleed_duration % 30 == 1) {
-	    CombatText::Instance()->addMessage(1, e->stats.pos, COMBAT_MESSAGE_GIVEDMG);
+	    CombatText::Instance()->addMessage(1, e->stats.pos, COMBAT_MESSAGE_GIVEDMG, false);
 		e->powers->activate(POWER_SPARK_BLOOD, &e->stats, e->stats.pos);
 	}
 

--- a/src/CombatText.h
+++ b/src/CombatText.h
@@ -43,27 +43,30 @@ class WidgetLabel;
 
 struct Combat_Text_Item {
 	WidgetLabel *label;
-    int lifespan;
-    Point pos;
-    std::string text;
-    int displaytype;
+	int lifespan;
+	Point pos;
+	Point src_pos;
+	std::string text;
+	int displaytype;
+	int ydelta;
+	bool from_hero;
 };
 
 class CombatText {
 public:
-    static CombatText* Instance();
-    void render();
-    void addMessage(std::string message, Point location, int displaytype);
-    void addMessage(int num, Point location, int displaytype);
-    void setCam(Point location);
+	static CombatText* Instance();
+	void render();
+	void addMessage(std::string message, Point location, int displaytype, bool from_hero);
+	void addMessage(int num, Point location, int displaytype, bool from_hero);
+	void setCam(Point location);
 
 private:
-    Point cam;
-    std::vector<Combat_Text_Item> combat_text;
-    CombatText();
-    CombatText(CombatText const&){};
+	Point cam;
+	std::vector<Combat_Text_Item> combat_text;
+	CombatText();
+	CombatText(CombatText const&){};
 
-    static CombatText* m_pInstance;
+	static CombatText* m_pInstance;
 
 	SDL_Color msg_color[5];
 	int duration;

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -148,7 +148,7 @@ bool Enemy::takeHit(Hazard h) {
 		int avoidance = stats.avoidance;
 		if (MAX_AVOIDANCE < avoidance) avoidance = MAX_AVOIDANCE;
 		if (rand() % 100 > (h.accuracy - avoidance + 25)) {
-		    combat_text->addMessage("miss", stats.pos, COMBAT_MESSAGE_MISS);
+		    combat_text->addMessage("miss", stats.pos, COMBAT_MESSAGE_MISS, false);
 		    return false;
 		}
 
@@ -199,11 +199,11 @@ bool Enemy::takeHit(Hazard h) {
 			map->shaky_cam_ticks = MAX_FRAMES_PER_SEC/2;
 
 			// show crit damage
-		    combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_CRIT);
+		    combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_CRIT, false);
 		}
 		else {
 		    // show normal damage
-		    combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_GIVEDMG);
+		    combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_GIVEDMG, false);
 		}
 
 		// apply damage
@@ -229,14 +229,14 @@ bool Enemy::takeHit(Hazard h) {
 		if (h.hp_steal != 0) {
 			int heal_amt = (dmg * h.hp_steal) / 100;
 			if (heal_amt == 0 && dmg > 0) heal_amt = 1;
-			combat_text->addMessage(heal_amt, h.src_stats->pos, COMBAT_MESSAGE_BUFF);
+			combat_text->addMessage(heal_amt, h.src_stats->pos, COMBAT_MESSAGE_BUFF, true);
 			h.src_stats->hp += heal_amt;
 			if (h.src_stats->hp > h.src_stats->maxhp) h.src_stats->hp = h.src_stats->maxhp;
 		}
 		if (h.mp_steal != 0) {
 			int heal_amt = (dmg * h.mp_steal) / 100;
 			if (heal_amt == 0 && dmg > 0) heal_amt = 1;
-			combat_text->addMessage(heal_amt, h.src_stats->pos, COMBAT_MESSAGE_BUFF);
+			combat_text->addMessage(heal_amt, h.src_stats->pos, COMBAT_MESSAGE_BUFF, true);
 			h.src_stats->mp += heal_amt;
 			if (h.src_stats->mp > h.src_stats->maxmp) h.src_stats->mp = h.src_stats->maxmp;
 		}

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -769,7 +769,10 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 			heal_amt = rand() % (heal_max - heal_min) + heal_min;
 		else // avoid div by 0
 			heal_amt = heal_min;
-		CombatText::Instance()->addMessage(msg->get("+%d HP",heal_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
+		if (src_stats->hero)
+			CombatText::Instance()->addMessage(msg->get("+%d HP",heal_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, true);
+		else
+			CombatText::Instance()->addMessage(msg->get("+%d HP",heal_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, false);
 		src_stats->hp += heal_amt;
 		if (src_stats->hp > src_stats->maxhp) src_stats->hp = src_stats->maxhp;
 	}
@@ -777,7 +780,10 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 	// hp restore
 	if (powers[power_index].buff_restore_hp > 0) {
 		int hp_amt = powers[power_index].buff_restore_hp;
-		CombatText::Instance()->addMessage(msg->get("+%d HP",hp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
+		if (src_stats->hero)
+			CombatText::Instance()->addMessage(msg->get("+%d HP",hp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, true);
+		else
+			CombatText::Instance()->addMessage(msg->get("+%d HP",hp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, false);
 		src_stats->hp += hp_amt;
 		if (src_stats->hp > src_stats->maxhp) src_stats->hp = src_stats->maxhp;
 	}
@@ -785,7 +791,10 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 	// mp restore
 	if (powers[power_index].buff_restore_mp > 0) {
 		int mp_amt = powers[power_index].buff_restore_mp;
-		CombatText::Instance()->addMessage(msg->get("+%d MP",mp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
+		if (src_stats->hero)
+			CombatText::Instance()->addMessage(msg->get("+%d MP",mp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, true);
+		else
+			CombatText::Instance()->addMessage(msg->get("+%d MP",mp_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, false);
 		src_stats->mp += mp_amt;
 		if (src_stats->mp > src_stats->maxmp) src_stats->mp = src_stats->maxmp;
 	}
@@ -793,7 +802,10 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 	// charge shield to max ment weapon damage * damage multiplier
 	if (powers[power_index].buff_shield) {
 	    int shield_amt = (int)ceil(src_stats->dmg_ment_max * powers[power_index].damage_multiplier / 100.0) + (src_stats->get_mental()*src_stats->bonus_per_mental);
-		CombatText::Instance()->addMessage(msg->get("+%d Shield",shield_amt), src_stats->pos, COMBAT_MESSAGE_BUFF);
+		if (src_stats->hero)
+			CombatText::Instance()->addMessage(msg->get("+%d Shield",shield_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, true);
+		else
+			CombatText::Instance()->addMessage(msg->get("+%d Shield",shield_amt), src_stats->pos, COMBAT_MESSAGE_BUFF, false);
 		src_stats->shield_hp = src_stats->shield_hp_total = shield_amt;
 	}
 


### PR DESCRIPTION
The old behavior for combat text was to set the screen position once, and then move it vertically according to speed. This worked fine for combat text that came from the hero (since the hero is always in the center). But when combat text spawned over an enemy, moving around would mess up the positioning. This pull fixes that.
