### PR TITLE
Updating mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,4 +2,10 @@
 Clint Bellanger <clintbellanger@gmail.com> clintbellanger <clintbellanger@gmail.com>
 Thane Brimhall <thane.brimhall@gmail.com> Thane Brimhall <thane@lenny.(none)>
 Thane Brimhall <thane.brimhall@gmail.com> Thane Brimhall <tbrimhall@turtle.(none)>
-
+Thane Brimhall <thane.brimhall@gmail.com> Thane Brimhall <thane@thane-laptop.(none)>
+Justin Jacobs <justin@justinjacobs.com> Justin Jacobs <jajdorkster@gmail.com>
+Matthew Krohn <makrohn@gmail.com> makrohn <makrohn@gmail.com>
+Stefan Beller <stefanbeller@googlemail.com> stefanbeller <stefanbeller@googlemail.com>
+Igor Paliychuk <mansonigor@gmail.com> igor <mansonigor@gmail.com>
+Chris Oelmueller <chris.oelmueller@gmail.com> Chris Oelmueller <eoc.eoc.eoc@gmail.com>
+Manuel A. Fernandez Montecelo <manuel.montezelo@gmail.com> Manuel A. Fernandez Montecelo <mafm@mafm-laptop.itsari.org>


### PR DESCRIPTION
Having an up-to-date mailmap file makes git shortlog a little more powerful, e.g. for estimating the number of different people(which is unequal to the number of different commiter names) who contributed so far.
