### PR TITLE
Fix some labels not displayed

### DIFF
--- a/src/WidgetLabel.cpp
+++ b/src/WidgetLabel.cpp
@@ -28,6 +28,9 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 using namespace std;
 
+LabelInfo::LabelInfo() : x(0), y(0), justify(JUSTIFY_LEFT), valign(VALIGN_TOP), hidden(false) {
+}
+
 /**
  * This is used in menus (e.g. MenuInventory) when parsing their config files
  */

--- a/src/WidgetLabel.h
+++ b/src/WidgetLabel.h
@@ -33,11 +33,13 @@ const int VALIGN_CENTER = 0;
 const int VALIGN_TOP = 1;
 const int VALIGN_BOTTOM = 2;
 
-typedef struct LabelInfo {
+struct LabelInfo {
 	int x,y;
 	int justify,valign;
 	bool hidden;
-}LabelInfo;
+
+	LabelInfo();
+};
 
 LabelInfo eatLabelInfo(std::string val);
 


### PR DESCRIPTION
Add default constructor to struct LabelInfo. Without this, it's initialized with garbage and some labels disappear as their LabelInfo::hidden field is set to true.

Should fix #963
